### PR TITLE
Use verbatim block for build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,24 +22,16 @@ migrated between threads.
 
 Buiding: Detailed instructions can be found at https://svn.boost.org/trac/boost/wiki/TryModBoost.
 
-git clone http://github.com/boostorg/boost modular-boost
+    git clone http://github.com/boostorg/boost modular-boost
+    cd modular-boost
+    git submodule update --init
+    cd libs
 
-cd modular-boost
+    git clone http://github.com/olk/boost-fiber fiber
+    cd ..
+    cmake -P forward_headers.cmake
+    ./bootstrap.sh
 
-git submodule update --init
-
-cd libs
-
-git clone http://github.com/olk/boost-fiber fiber
-
-cd ..
-
-cmake -P forward_headers.cmake
-
-./bootstrap.sh
-
-cp b2 /usr/local/bin
-
-cd libs/fiber/test
-
-b2
+    cp b2 /usr/local/bin
+    cd libs/fiber/test
+    b2


### PR DESCRIPTION
This just indents the code instructions (which for Markdown turns it into a verbatim block) for pretty printing.
