### PR TITLE
Expressions with side effects in BOOST_ASSERT() fail in release builds. :-P

### DIFF
--- a/include/boost/fiber/detail/scheduler.hpp
+++ b/include/boost/fiber/detail/scheduler.hpp
@@ -103,13 +103,18 @@ public:
     /// By default, use a thread-exit cleanup function that deletes T*.
     thread_local_ptr() BOOST_NOEXCEPT
     {
-        BOOST_ASSERT( ! ::pthread_key_create( & key_,
-                                              &thread_local_ptr::deleter_fn ) );
+        int ok = ::pthread_key_create( & key_, &thread_local_ptr::deleter_fn );
+        BOOST_ASSERT( ok == 0 );
+        (void)ok;
     }
 
     /// Allow caller to override cleanup function, 0 to suppress
     thread_local_ptr( cleanup_function cf ) BOOST_NOEXCEPT
-    { BOOST_ASSERT( ! ::pthread_key_create( & key_, cf ) ); }
+    {
+        int ok = ::pthread_key_create( & key_, cf );
+        BOOST_ASSERT( ok == 0 );
+        (void)ok;
+    }
 
     BOOST_EXPLICIT_OPERATOR_BOOL();
 

--- a/include/boost/fiber/detail/worker_fiber.hpp
+++ b/include/boost/fiber/detail/worker_fiber.hpp
@@ -147,24 +147,28 @@ public:
     {
         state_t previous = state_.exchange( TERMINATED);
         BOOST_ASSERT( RUNNING == previous);
+        (void)previous;
     }
 
     void set_ready() BOOST_NOEXCEPT
     {
         state_t previous = state_.exchange( READY);
         BOOST_ASSERT( WAITING == previous || RUNNING == previous || READY == previous);
+        (void)previous;
     }
 
     void set_running() BOOST_NOEXCEPT
     {
         state_t previous = state_.exchange( RUNNING);
         BOOST_ASSERT( READY == previous);
+        (void)previous;
     }
 
     void set_waiting() BOOST_NOEXCEPT
     {
         state_t previous = state_.exchange( WAITING);
         BOOST_ASSERT( RUNNING == previous);
+        (void)previous;
     }
 
     void * get_fss_data( void const* vp) const;


### PR DESCRIPTION
Also suppress a few 'unused variable' warnings.
