### PR TITLE
optimize the fetch_ready. Break early after got ready fiber and reduce t...

### DIFF
--- a/include/boost/fiber/detail/waiting_queue.hpp
+++ b/include/boost/fiber/detail/waiting_queue.hpp
@@ -97,10 +97,11 @@ public:
         BOOST_ASSERT( sched_algo);
 
         worker_fiber * f = head_, * prev = 0;
+        clock_type::time_point now = clock_type::now();
         while ( 0 != f)
         {
             worker_fiber * nxt = f->next();
-            if ( fn( f) )
+            if ( fn( f, now) )
             {
                 if ( f == head_)
                 {
@@ -122,6 +123,7 @@ public:
                 f->next_reset();
                 f->time_point_reset();
                 sched_algo->awakened( f);
+                break;
             }
             else
                 prev = f;

--- a/src/fiber_manager.cpp
+++ b/src/fiber_manager.cpp
@@ -30,14 +30,14 @@
 namespace boost {
 namespace fibers {
 
-bool fetch_ready( detail::worker_fiber * f)
+bool fetch_ready( detail::worker_fiber * f, const clock_type::time_point& now)
 {
     BOOST_ASSERT( ! f->is_running() );
     BOOST_ASSERT( ! f->is_terminated() );
 
     // set fiber to state_ready if dead-line was reached
     // set fiber to state_ready if interruption was requested
-    if ( f->time_point() <= clock_type::now() || f->interruption_requested() )
+    if ( f->time_point() <= now || f->interruption_requested() )
         f->set_ready();
     return f->is_ready();
 }


### PR DESCRIPTION
Improve the performance when there are lots of fibers created. The original code will have some overhead on the clock_type::now(). Also, since the schedule algorithm need only one fiber to get running, the "move_to" function can break early to improve the performance.
