### PR TITLE
Fix allocator-aware fiber::async() overload allocator forwarding.

### DIFF
--- a/include/boost/fiber/future/async.hpp
+++ b/include/boost/fiber/future/async.hpp
@@ -80,7 +80,8 @@ async( Policy policy, std::allocator_arg_t, StackAllocator salloc, Fn && fn, Arg
     packaged_task< result_t( typename std::decay< Args >::type ... ) > pt{
         std::allocator_arg, salloc, std::forward< Fn >( fn) };
     future< result_t > f{ pt.get_future() };
-    fiber{ policy, std::move( pt), std::forward< Args >( args) ... }.detach();
+    fiber{ policy, std::allocator_arg, salloc,
+        std::move( pt), std::forward< Args >( args) ... }.detach();
     return f;
 }
 


### PR DESCRIPTION
I'm using a custom valgrind-aware allocator for creating fiber so that
the valgrind log is clean.

It worked well with fiber::fiber() but wasn't used in fiber::async(). 
Unless there are reasons unknown to me, I believe this to be an oversight, and this
commit fixes it.