### PR TITLE
Fix fibers::asio::round_robin's notify() method.

### DIFF
--- a/examples/asio/round_robin.hpp
+++ b/examples/asio/round_robin.hpp
@@ -178,6 +178,9 @@ public:
         // once for the operation_aborted handler, once for timer expiration
         // -- but that shouldn't be a big problem.
         suspend_timer_.expires_at( std::chrono::steady_clock::now() );
+        suspend_timer_.async_wait([](boost::system::error_code const&){
+            this_fiber::yield();
+          });
     }
 //]
 };


### PR DESCRIPTION
The notify() method of fibers::asio::round_robin doesn't give
a chance to pending fibers to run.

See #100 for more detail.