### PR TITLE
fix cpu_relax.h for compilation with Intel compiler on Windows

### DIFF
--- a/include/boost/fiber/detail/cpu_relax.hpp
+++ b/include/boost/fiber/detail/cpu_relax.hpp
@@ -14,7 +14,7 @@
 
 #include <boost/fiber/detail/config.hpp>
 
-#if BOOST_COMP_MSVC
+#if BOOST_COMP_MSVC || BOOST_COMP_MSVC_EMULATED
 # include <Windows.h>
 #endif
 
@@ -37,7 +37,7 @@ namespace detail {
 #elif BOOST_ARCH_PPC
 # define cpu_relax() asm volatile ("or 27,27,27" ::: "memory");
 #elif BOOST_ARCH_X86
-# if BOOST_COMP_MSVC
+# if BOOST_COMP_MSVC || BOOST_COMP_MSVC_EMULATED
 #  define cpu_relax() YieldProcessor();
 # else
 #  define cpu_relax() asm volatile ("pause" ::: "memory");


### PR DESCRIPTION
Hello,
I'm trying to build the boost 1.63 library with the Intel 17.0 compiler (latest update) in the vs2015 environment. Several targets fail to build because the definition of the cpu_relax macro isn't correct.

This change corrects the problem and allows the build to complete successfully.  Is this the right way to correct the problem? At Intel, we like to set up the Intel compiler so the macro symbols emulate our "host" compiler, cl.exe on Windows and gcc on Linux. This way whatever work folks put into making boost (or some other project) work for cl.exe should also work for the Intel compiler (or it would be a compiler bug that should be fixed)

 Without this change I get a message like this:

./boost/fiber/detail/spinlock_ttas.hpp(66): error: invalid constant in assembly language instruction
                      asm volatile ("pause" ::: "memory");;
                                    ^

This change allows the macro to compile to YieldProcessor()

I work for Intel, on the Intel C++ compiler.

Thanks and regards, Melanie Blower