### PR TITLE
Also compile on platforms without alignas and thread_local

### DIFF
--- a/include/boost/fiber/algo/work_stealing.hpp
+++ b/include/boost/fiber/algo/work_stealing.hpp
@@ -38,9 +38,9 @@ private:
     std::size_t                                             idx_;
     std::size_t                                             max_idx_;
 #ifdef BOOST_FIBERS_USE_SPMC_QUEUE
-    alignas(cache_alignment) detail::context_spmc_queue     rqueue_{};
+    BOOST_FIBER_ALIGNAS(cache_alignment, detail::context_spmc_queue)     rqueue_{};
 #else
-    alignas(cache_alignment) detail::context_spinlock_queue rqueue_{};
+    BOOST_FIBER_ALIGNAS(cache_alignment, detail::context_spinlock_queue) rqueue_{};
 #endif
     std::mutex                                              mtx_{};
     std::condition_variable                                 cnd_{};

--- a/include/boost/fiber/buffered_channel.hpp
+++ b/include/boost/fiber/buffered_channel.hpp
@@ -42,25 +42,25 @@ private:
     typedef typename std::aligned_storage< sizeof( T), alignof( T) >::type  storage_type;
     typedef context::wait_queue_t                                           wait_queue_type;
 
-    struct alignas(cache_alignment) slot {
+    struct BOOST_FIBER_ALIGNAS(cache_alignment, slot {
         std::atomic< std::size_t >  cycle{ 0 };
         storage_type                storage{};
 
         slot() = default;
-    };
+    });
 
     // procuder cacheline
-    alignas(cache_alignment) std::atomic< std::size_t >     producer_idx_{ 0 };
+    BOOST_FIBER_ALIGNAS(cache_alignment, std::atomic< std::size_t >) producer_idx_{ 0 };
     // consumer cacheline
-    alignas(cache_alignment) std::atomic< std::size_t >     consumer_idx_{ 0 };
+    BOOST_FIBER_ALIGNAS(cache_alignment, std::atomic< std::size_t >) consumer_idx_{ 0 };
     // shared write cacheline
-    alignas(cache_alignment) std::atomic_bool               closed_{ false };
-    alignas(cache_alignment) mutable detail::spinlock       splk_producers_{};
+    BOOST_FIBER_ALIGNAS(cache_alignment, std::atomic_bool)  closed_{ false };
+    BOOST_FIBER_ALIGNAS(cache_alignment, mutable detail::spinlock) splk_producers_{};
     wait_queue_type                                         waiting_producers_{};
-    alignas(cache_alignment) mutable detail::spinlock       splk_consumers_{};
+    BOOST_FIBER_ALIGNAS(cache_alignment, mutable detail::spinlock) splk_consumers_{};
     wait_queue_type                                         waiting_consumers_{};
     // shared read cacheline
-    alignas(cache_alignment) slot                        *  slots_{ nullptr };
+    BOOST_FIBER_ALIGNAS(cache_alignment, slot *)                     slots_{ nullptr };
     std::size_t                                             capacity_;
     char                                                    pad_[cacheline_length];
 

--- a/include/boost/fiber/context.hpp
+++ b/include/boost/fiber/context.hpp
@@ -175,21 +175,21 @@ private:
     typedef std::map< uintptr_t, fss_data >             fss_data_t;
 
 #if ! defined(BOOST_FIBERS_NO_ATOMICS)
-    alignas(cache_alignment) std::atomic< std::size_t > use_count_{ 0 };
+    BOOST_FIBER_ALIGNAS(cache_alignment, std::atomic< std::size_t >) use_count_{ 0 };
 #else
-    alignas(cache_alignment) std::size_t                use_count_{ 0 };
+    BOOST_FIBER_ALIGNAS(cache_alignment, std::size_t)                use_count_{ 0 };
 #endif
 #if ! defined(BOOST_FIBERS_NO_ATOMICS)
-    alignas(cache_alignment) detail::remote_ready_hook  remote_ready_hook_{};
+    BOOST_FIBER_ALIGNAS(cache_alignment, detail::remote_ready_hook)  remote_ready_hook_{};
     std::atomic< context * >                            remote_nxt_{ nullptr };
 #endif
-    alignas(cache_alignment) detail::spinlock           splk_{};
+    BOOST_FIBER_ALIGNAS(cache_alignment, detail::spinlock)           splk_{};
     bool                                                terminated_{ false };
     wait_queue_t                                        wait_queue_{};
 public:
     detail::wait_hook                                   wait_hook_{};
 private:
-    alignas(cache_alignment) scheduler              *   scheduler_{ nullptr };
+    BOOST_FIBER_ALIGNAS(cache_alignment, scheduler)              *   scheduler_{ nullptr };
     fss_data_t                                          fss_data_{};
     detail::sleep_hook                                  sleep_hook_{};
     detail::ready_hook                                  ready_hook_{};

--- a/include/boost/fiber/detail/context_spinlock_queue.hpp
+++ b/include/boost/fiber/detail/context_spinlock_queue.hpp
@@ -30,7 +30,7 @@ class context_spinlock_queue {
 private:
 	typedef context *   slot_type;
 
-    alignas(cache_alignment) mutable spinlock   splk_{};
+    BOOST_FIBER_ALIGNAS(cache_alignment, mutable spinlock)   splk_{};
 	std::size_t                                 pidx_{ 0 };
 	std::size_t                                 cidx_{ 0 };
 	std::size_t                                 capacity_;

--- a/include/boost/fiber/detail/context_spmc_queue.hpp
+++ b/include/boost/fiber/detail/context_spmc_queue.hpp
@@ -92,9 +92,9 @@ private:
         }
     };
 
-    alignas(cache_alignment) std::atomic< std::size_t >     top_{ 0 };
-    alignas(cache_alignment) std::atomic< std::size_t >     bottom_{ 0 };
-    alignas(cache_alignment) std::atomic< array * >         array_;
+    BOOST_FIBER_ALIGNAS(cache_alignment, std::atomic< std::size_t >) top_{ 0 };
+    BOOST_FIBER_ALIGNAS(cache_alignment, std::atomic< std::size_t >) bottom_{ 0 };
+    BOOST_FIBER_ALIGNAS(cache_alignment, std::atomic< array * >)     array_;
     std::vector< array * >                                  old_arrays_{};
     char                                                    padding_[cacheline_length];
 

--- a/include/boost/fiber/detail/spinlock_ttas.hpp
+++ b/include/boost/fiber/detail/spinlock_ttas.hpp
@@ -10,6 +10,7 @@
 #include <atomic>
 #include <chrono>
 #include <random>
+#define __GLIBCXX_USE_NANOSLEEP
 #include <thread>
 
 #include <boost/fiber/detail/config.hpp>
@@ -91,9 +92,9 @@ public:
                 // spinlock now contended
                 // utilize 'Binary Exponential Backoff' algorithm
                 // linear_congruential_engine is a random number engine based on Linear congruential generator (LCG)
-                static thread_local std::minstd_rand generator;
+                static BOOST_FIBER_DEFINE_THREAD_LOCAL(std::minstd_rand, generator);
                 const std::size_t z =
-                    std::uniform_int_distribution< std::size_t >{ 0, static_cast< std::size_t >( 1) << collisions }( generator);
+                    std::uniform_int_distribution< std::size_t >{ 0, static_cast< std::size_t >( 1) << collisions }(BOOST_FIBER_USE_THREAD_LOCAL(generator));
                 ++collisions;
                 for ( std::size_t i = 0; i < z; ++i) {
                     // -> reduces the power consumed by the CPU

--- a/include/boost/fiber/detail/spinlock_ttas_adaptive.hpp
+++ b/include/boost/fiber/detail/spinlock_ttas_adaptive.hpp
@@ -90,9 +90,9 @@ public:
                 // spinlock now contended
                 // utilize 'Binary Exponential Backoff' algorithm
                 // linear_congruential_engine is a random number engine based on Linear congruential generator (LCG)
-                static thread_local std::minstd_rand generator;
+                static BOOST_FIBER_DEFINE_THREAD_LOCAL(std::minstd_rand, generator);
                 const std::size_t z =
-                    std::uniform_int_distribution< std::size_t >{ 0, static_cast< std::size_t >( 1) << collisions }( generator);
+                    std::uniform_int_distribution< std::size_t >{ 0, static_cast< std::size_t >( 1) << collisions }(BOOST_FIBER_USE_THREAD_LOCAL(generator));
                 ++collisions;
                 for ( std::size_t i = 0; i < z; ++i) {
                     // -> reduces the power consumed by the CPU

--- a/include/boost/fiber/detail/spinlock_ttas_adaptive_futex.hpp
+++ b/include/boost/fiber/detail/spinlock_ttas_adaptive_futex.hpp
@@ -70,9 +70,9 @@ public:
                 // spinlock now contended
                 // utilize 'Binary Exponential Backoff' algorithm
                 // linear_congruential_engine is a random number engine based on Linear congruential generator (LCG)
-                static thread_local std::minstd_rand generator;
+                static BOOST_FIBER_DEFINE_THREAD_LOCAL(std::minstd_rand, generator);
                 const std::int32_t z = std::uniform_int_distribution< std::int32_t >{
-                    0, static_cast< std::int32_t >( 1) << collisions }( generator);
+                    0, static_cast< std::int32_t >( 1) << collisions }(BOOST_FIBER_USE_THREAD_LOCAL(generator));
                 ++collisions;
                 for ( std::int32_t i = 0; i < z; ++i) {
                     // -> reduces the power consumed by the CPU

--- a/include/boost/fiber/detail/spinlock_ttas_futex.hpp
+++ b/include/boost/fiber/detail/spinlock_ttas_futex.hpp
@@ -66,9 +66,9 @@ public:
                 // spinlock now contended
                 // utilize 'Binary Exponential Backoff' algorithm
                 // linear_congruential_engine is a random number engine based on Linear congruential generator (LCG)
-                static thread_local std::minstd_rand generator;
+                static BOOST_FIBER_DEFINE_THREAD_LOCAL(std::minstd_rand, generator);
                 const std::int32_t z = std::uniform_int_distribution< std::int32_t >{
-                    0, static_cast< std::int32_t >( 1) << collisions }( generator);
+                    0, static_cast< std::int32_t >( 1) << collisions }(BOOST_FIBER_USE_THREAD_LOCAL(generator));
                 ++collisions;
                 for ( std::int32_t i = 0; i < z; ++i) {
                     // -> reduces the power consumed by the CPU

--- a/include/boost/fiber/scheduler.hpp
+++ b/include/boost/fiber/scheduler.hpp
@@ -90,7 +90,7 @@ private:
     detail::spinlock                                            remote_ready_splk_{};
     remote_ready_queue_type                                     remote_ready_queue_{};
 #endif
-    alignas(cache_alignment) std::unique_ptr< algo::algorithm > algo_;
+    BOOST_FIBER_ALIGNAS(cache_alignment, std::unique_ptr< algo::algorithm >) algo_;
     // sleep-queue contains context' which have been called
     // scheduler::wait_until()
     sleep_queue_type                                            sleep_queue_{};

--- a/include/boost/fiber/unbuffered_channel.hpp
+++ b/include/boost/fiber/unbuffered_channel.hpp
@@ -38,7 +38,7 @@ public:
 private:
     typedef context::wait_queue_t   wait_queue_type;
 
-    struct alignas(cache_alignment) slot {
+    struct BOOST_FIBER_ALIGNAS_BEGIN(cache_alignment) slot {
         value_type  value;
         context *   ctx;
 
@@ -51,15 +51,15 @@ private:
             value{ std::move( value_) },
             ctx{ ctx_ } {
         }
-    };
+    } BOOST_FIBER_ALIGNAS_END(cache_alignment);
 
     // shared cacheline
-    alignas(cache_alignment) std::atomic< slot * >      slot_{ nullptr };
+    BOOST_FIBER_ALIGNAS(cache_alignment, std::atomic< slot * >)      slot_{ nullptr };
     // shared cacheline
-    alignas(cache_alignment) std::atomic_bool           closed_{ false };
-    alignas(cache_alignment) mutable detail::spinlock   splk_producers_{};
+    BOOST_FIBER_ALIGNAS(cache_alignment, std::atomic_bool)           closed_{ false };
+    BOOST_FIBER_ALIGNAS(cache_alignment, mutable detail::spinlock)   splk_producers_{};
     wait_queue_type                                     waiting_producers_{};
-    alignas( cache_alignment) mutable detail::spinlock  splk_consumers_{};
+    BOOST_FIBER_ALIGNAS(cache_alignment, mutable detail::spinlock)  splk_consumers_{};
     wait_queue_type                                     waiting_consumers_{};
     char                                                pad_[cacheline_length];
 

--- a/performance/thread/buffered_channel.hpp
+++ b/performance/thread/buffered_channel.hpp
@@ -40,24 +40,24 @@ public:
 private:
     typedef typename std::aligned_storage< sizeof( T), alignof( T) >::type  storage_type;
 
-    struct alignas(cache_alignment) slot {
+    struct BOOST_FIBER_ALIGNAS(cache_alignment, slot {
         std::atomic< std::size_t >  cycle{ 0 };
         storage_type                storage{};
 
         slot() = default;
-    };
+    });
 
-    // procuder cacheline
-    alignas(cache_alignment) std::atomic< std::size_t >     producer_idx_{ 0 };
+    // producer cacheline
+    BOOST_FIBER_ALIGNAS(cache_alignment, std::atomic< std::size_t >)     producer_idx_{ 0 };
     // consumer cacheline
-    alignas(cache_alignment) std::atomic< std::size_t >     consumer_idx_{ 0 };
+    BOOST_FIBER_ALIGNAS(cache_alignment, std::atomic< std::size_t >)     consumer_idx_{ 0 };
     // shared write cacheline
-    alignas(cache_alignment) std::atomic_bool               closed_{ false };
+    BOOST_FIBER_ALIGNAS(cache_alignment, std::atomic_bool)               closed_{ false };
     mutable std::mutex                                      mtx_{};
     std::condition_variable                                 not_full_cnd_{};
     std::condition_variable                                 not_empty_cnd_{};
     // shared read cacheline
-    alignas(cache_alignment) slot                        *  slots_{ nullptr };
+    BOOST_FIBER_ALIGNAS(cache_alignment, slot                        *)  slots_{ nullptr };
     std::size_t                                             capacity_;
     char                                                    pad_[cacheline_length];
     std::size_t                                             waiting_consumer_{ 0 };

--- a/src/algo/work_stealing.cpp
+++ b/src/algo/work_stealing.cpp
@@ -52,10 +52,10 @@ work_stealing::pick_next() noexcept {
             context::active()->attach( ctx);
         }
     } else {
-        static thread_local std::minstd_rand generator;
+        static BOOST_FIBER_DEFINE_THREAD_LOCAL(std::minstd_rand, generator);
         std::size_t idx = 0;
         do {
-            idx = std::uniform_int_distribution< std::size_t >{ 0, max_idx_ }( generator);
+            idx = std::uniform_int_distribution< std::size_t >{ 0, max_idx_ }(BOOST_FIBER_USE_THREAD_LOCAL(generator));
         } while ( idx == idx_);
         ctx = schedulers_[idx]->steal();
         if ( nullptr != ctx) {


### PR DESCRIPTION
I created this "workaround" to also get Boost Fiber working on iOS and QNX builds. These changes will very likely affect the performance on those platforms and invalidate the current benchmarks. It should have no effect on the platforms which already supported thread_local and alignas.

iOS does not support the thread_local keyword at all. Even in the latest XCode version when it was introduced for the OSX platform.

QNX uses a gcc 4.7 compiler which has no thread_local support but general C++11 support.