### PR TITLE
unbalanced opening parenthesis

### DIFF
--- a/include/boost/fiber/future/detail/task_object.hpp
+++ b/include/boost/fiber/future/detail/task_object.hpp
@@ -58,7 +58,7 @@ public:
                         fn_, std::make_tuple( std::forward< Args >( args) ... ) )
 #else
                     std::apply(
-                        fn_, std::make_tuple( std::forward< Args >( args) ... )
+                        fn_, std::make_tuple( std::forward< Args >( args) ... ) )
 #endif
                     );
         } catch (...) {


### PR DESCRIPTION
Hallo Oliver,

with msvc 19.10 and compiler option /std:c++latest activated, the code path using std::apply is engaged and triggers a typo 😄 

Signed-off-by: Daniela Engert <dani@ngrt.de>