### PR TITLE
Work around compiler limitations in g++-4.9

### DIFF
--- a/include/boost/fiber/detail/wrap.hpp
+++ b/include/boost/fiber/detail/wrap.hpp
@@ -42,10 +42,10 @@ private:
 public:
     wrapper( Fn1 && fn1, Fn2 && fn2, Tpl && tpl,
              boost::context::execution_context const& ctx) :
-        fn1_{ std::move( fn1) },
-        fn2_{ std::move( fn2) },
-        tpl_{ std::move( tpl) },
-        ctx_{ ctx } {
+        fn1_( std::move( fn1) ),
+        fn2_( std::move( fn2) ),
+        tpl_( std::move( tpl) ),
+        ctx_( ctx ) {
     }
 
     wrapper( wrapper const&) = delete;
@@ -83,9 +83,9 @@ private:
 
 public:
     wrapper( Fn1 && fn1, Fn2 && fn2, Tpl && tpl) :
-        fn1_{ std::move( fn1) },
-        fn2_{ std::move( fn2) },
-        tpl_{ std::move( tpl) } {
+        fn1_( std::move( fn1) ),
+        fn2_( std::move( fn2) ),
+        tpl_( std::move( tpl) ) {
     }
 
     wrapper( wrapper const&) = delete;

--- a/include/boost/fiber/future/detail/shared_state.hpp
+++ b/include/boost/fiber/future/detail/shared_state.hpp
@@ -164,7 +164,7 @@ private:
         if ( ready_) {
             throw promise_already_satisfied{};
         }
-        ::new ( static_cast< void * >( std::addressof( storage_) ) ) R{ value };
+        ::new ( static_cast< void * >( std::addressof( storage_) ) ) R( value );
         mark_ready_and_notify_( lk);
     }
 
@@ -173,7 +173,7 @@ private:
         if ( ready_) {
             throw promise_already_satisfied{};
         }
-        ::new ( static_cast< void * >( std::addressof( storage_) ) ) R{ std::move( value) };
+        ::new ( static_cast< void * >( std::addressof( storage_) ) ) R( std::move( value) );
         mark_ready_and_notify_( lk);
     }
 


### PR DESCRIPTION
GCC before v5 has issues invoking copy constructors using braces:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=51747