### PR TITLE
Construct using the raw pointer and use pointer_traits.to_address

### DIFF
--- a/include/boost/fiber/detail/convert.hpp
+++ b/include/boost/fiber/detail/convert.hpp
@@ -34,22 +34,6 @@ std::chrono::steady_clock::time_point convert(
     return std::chrono::steady_clock::now() + ( timeout_time - Clock::now() );
 }
 
-// suggested by Howard Hinnant
-template< typename T >
-inline
-T * convert( T * p) noexcept {
-    return p;
-}
-
-template< typename Pointer >
-inline
-typename std::pointer_traits< Pointer >::element_type *
-convert( Pointer p) noexcept {
-    return nullptr != p
-        ? to_raw_pointer( p.operator->() )
-        : nullptr;
-}
-
 }}}
 
 #ifdef BOOST_HAS_ABI_HEADERS

--- a/include/boost/fiber/future/detail/task_object.hpp
+++ b/include/boost/fiber/future/detail/task_object.hpp
@@ -16,6 +16,7 @@
 #if defined(BOOST_NO_CXX17_STD_APPLY)
 #include <boost/context/detail/apply.hpp>
 #endif
+#include <boost/core/pointer_traits.hpp>
 
 #include <boost/fiber/detail/config.hpp>
 #include <boost/fiber/future/detail/task_base.hpp>
@@ -68,15 +69,17 @@ public:
 
     typename base_type::ptr_type reset() override final {
         typedef std::allocator_traits< allocator_type >    traity_type;
+        typedef pointer_traits< typename traity_type::pointer> ptrait_type;
 
         typename traity_type::pointer ptr{ traity_type::allocate( alloc_, 1) };
+        typename ptrait_type::element_type* p = ptrait_type::to_address(ptr);
         try {
-            traity_type::construct( alloc_, ptr, alloc_, std::move( fn_) );
+            traity_type::construct( alloc_, p, alloc_, std::move( fn_) );
         } catch (...) {
             traity_type::deallocate( alloc_, ptr, 1);
             throw;
         }
-        return { convert( ptr) };
+        return { p };
     }
 
 protected:
@@ -134,15 +137,17 @@ public:
 
     typename base_type::ptr_type reset() override final {
         typedef std::allocator_traits< allocator_type >    traity_type;
+        typedef pointer_traits< typename traity_type::pointer> ptrait_type;
 
         typename traity_type::pointer ptr{ traity_type::allocate( alloc_, 1) };
+        typename ptrait_type::element_type* p = ptrait_type::to_address(ptr);
         try {
-            traity_type::construct( alloc_, ptr, alloc_, std::move( fn_) );
+            traity_type::construct( alloc_, p, alloc_, std::move( fn_) );
         } catch (...) {
             traity_type::deallocate( alloc_, ptr, 1);
             throw;
         }
-        return { convert( ptr) };
+        return { p };
     }
 
 protected:

--- a/include/boost/fiber/future/packaged_task.hpp
+++ b/include/boost/fiber/future/packaged_task.hpp
@@ -14,7 +14,6 @@
 
 #include <boost/config.hpp>
 
-#include <boost/fiber/detail/convert.hpp>
 #include <boost/fiber/detail/disable_overload.hpp>
 #include <boost/fiber/exceptions.hpp>
 #include <boost/fiber/future/detail/task_base.hpp>
@@ -57,16 +56,18 @@ public:
         typedef std::allocator_traits<
             typename object_type::allocator_type
         >                                       traits_type;
+        typedef pointer_traits< typename traits_type::pointer > ptrait_type;
 
         typename object_type::allocator_type a{ alloc };
         typename traits_type::pointer ptr{ traits_type::allocate( a, 1) };
+        typename ptrait_type::element_type* p = ptrait_type::to_address(ptr);
         try {
-            traits_type::construct( a, ptr, a, std::forward< Fn >( fn) );
+            traits_type::construct( a, p, a, std::forward< Fn >( fn) );
         } catch (...) {
             traits_type::deallocate( a, ptr, 1);
             throw;
         }
-        task_.reset( convert( ptr) );
+        task_.reset(p);
     }
 
     ~packaged_task() {

--- a/include/boost/fiber/future/promise.hpp
+++ b/include/boost/fiber/future/promise.hpp
@@ -12,8 +12,8 @@
 #include <utility>
 
 #include <boost/config.hpp>
+#include <boost/core/pointer_traits.hpp>
 
-#include <boost/fiber/detail/convert.hpp>
 #include <boost/fiber/exceptions.hpp>
 #include <boost/fiber/future/detail/shared_state.hpp>
 #include <boost/fiber/future/detail/shared_state_object.hpp>
@@ -38,16 +38,18 @@ struct promise_base {
     promise_base( std::allocator_arg_t, Allocator alloc) {
         typedef detail::shared_state_object< R, Allocator >  object_type;
         typedef std::allocator_traits< typename object_type::allocator_type > traits_type;
+        typedef pointer_traits< typename traits_type::pointer > ptrait_type;
         typename object_type::allocator_type a{ alloc };
         typename traits_type::pointer ptr{ traits_type::allocate( a, 1) };
+        typename ptrait_type::element_type* p = ptrait_type::to_address(ptr);
 
         try {
-            traits_type::construct( a, ptr, a);
+            traits_type::construct( a, p, a);
         } catch (...) {
             traits_type::deallocate( a, ptr, 1);
             throw;
         }
-        future_.reset( convert( ptr) );
+        future_.reset(p);
     }
 
     ~promise_base() {


### PR DESCRIPTION
The place to use the conversion from a potentially-fancy pointer to a raw pointer is also with construct() since that requires raw pointers.