### PR TITLE
Changed #include "Windows.h" to "windows.h" to fix cross-compilation

### DIFF
--- a/include/boost/fiber/detail/futex.hpp
+++ b/include/boost/fiber/detail/futex.hpp
@@ -18,7 +18,7 @@ extern "C" {
 #include <sys/syscall.h>
 }
 #elif BOOST_OS_WINDOWS
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 namespace boost {


### PR DESCRIPTION
to fix cross-compilation error with MinGW and Posix threads.