### PR TITLE
explicitly include <string.h> for memset()

### DIFF
--- a/src/numa/linux/pin_thread.cpp
+++ b/src/numa/linux/pin_thread.cpp
@@ -9,6 +9,7 @@
 extern "C" {
 #include <pthread.h>
 #include <sched.h>
+#include <string.h>
 }
 
 #include <system_error>


### PR DESCRIPTION
Fixes:

```
In file included from /usr/include/pthread.h:30:0,
                 from libs/fiber/src/numa/linux/pin_thread.cpp:10:
libs/fiber/src/numa/linux/pin_thread.cpp: In function 'void boost::fibers::numa::pin_thread(uint32_t)':
libs/fiber/src/numa/linux/pin_thread.cpp:27:5: error: 'memset' was not declared in this scope
    CPU_ZERO( & set);
    ^
```