### PR TITLE
Re-enable libstdc++ 4.8

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -98,7 +98,6 @@ lib boost_fiber
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_tuple
                cxx11_lambdas
                cxx11_noexcept

--- a/src/numa/linux/topology.cpp
+++ b/src/numa/linux/topology.cpp
@@ -5,6 +5,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include "boost/fiber/numa/topology.hpp"
+#include "boost/fiber/exceptions.hpp"
 
 #include <exception>
 #include <map>
@@ -23,6 +24,8 @@
 #ifdef BOOST_HAS_ABI_HEADERS
 # include BOOST_ABI_PREFIX
 #endif
+
+#if !defined(BOOST_NO_CXX11_HDR_REGEX)
 
 namespace al = boost::algorithm;
 namespace fs = boost::filesystem;
@@ -189,6 +192,31 @@ std::vector< node > topology() {
 }
 
 }}}
+
+#else
+
+namespace boost {
+namespace fibers {
+namespace numa {
+
+#if BOOST_COMP_CLANG || \
+    BOOST_COMP_GNUC || \
+    BOOST_COMP_INTEL ||  \
+    BOOST_COMP_MSVC
+# pragma message "topology() not supported without <regex>"
+#endif
+
+BOOST_FIBERS_DECL
+std::vector< node > topology() {
+    throw fiber_error{
+        std::make_error_code( std::errc::function_not_supported),
+            "boost fiber: topology() not supported without <regex>" };
+    return std::vector< node >{};
+}
+
+}}}
+
+#endif
 
 #ifdef BOOST_HAS_ABI_HEADERS
 # include BOOST_ABI_SUFFIX

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -41,6 +41,10 @@ rule topology-impl ( properties * )
     {
         result = <build>no ;
     }
+    else if ( <target-os>linux in $(properties) )
+    {
+        result = [ requires cxx11_hdr_regex ] ;
+    }
     return $(result) ;
 }
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -41,10 +41,6 @@ rule topology-impl ( properties * )
     {
         result = <build>no ;
     }
-    else if ( <target-os>linux in $(properties) )
-    {
-        result = [ requires cxx11_hdr_regex ] ;
-    }
     return $(result) ;
 }
 
@@ -78,6 +74,7 @@ test-suite numa :
                cxx11_hdr_mutex
                cxx11_hdr_thread
                cxx11_hdr_tuple
+               cxx11_hdr_regex
                cxx11_lambdas
                cxx11_noexcept
                cxx11_nullptr

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -72,7 +72,6 @@ test-suite numa :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -94,7 +93,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -114,7 +112,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -134,7 +131,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -154,7 +150,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -174,7 +169,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -194,7 +188,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -214,7 +207,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -234,7 +226,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -254,7 +245,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -274,7 +264,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -294,7 +283,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -314,7 +302,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -334,7 +321,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -354,7 +340,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -374,7 +359,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -394,7 +378,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -414,7 +397,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -434,7 +416,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -454,7 +435,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -474,7 +454,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -494,7 +473,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -514,7 +492,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -534,7 +511,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -554,7 +530,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -574,7 +549,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -594,7 +568,6 @@ test-suite asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -617,7 +590,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -637,7 +609,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -657,7 +628,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -677,7 +647,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -697,7 +666,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -717,7 +685,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -737,7 +704,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -757,7 +723,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -777,7 +742,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -797,7 +761,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -817,7 +780,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -837,7 +799,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -857,7 +818,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -877,7 +837,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -897,7 +856,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -917,7 +875,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -937,7 +894,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -957,7 +913,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -977,7 +932,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -997,7 +951,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1017,7 +970,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1037,7 +989,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1057,7 +1008,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1077,7 +1027,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1097,7 +1046,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1117,7 +1065,6 @@ test-suite native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1140,7 +1087,6 @@ test-suite extra-asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1160,7 +1106,6 @@ test-suite extra-asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1180,7 +1125,6 @@ test-suite extra-asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1200,7 +1144,6 @@ test-suite extra-asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1220,7 +1163,6 @@ test-suite extra-asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1240,7 +1182,6 @@ test-suite extra-asm :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1263,7 +1204,6 @@ test-suite extra-native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1283,7 +1223,6 @@ test-suite extra-native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1303,7 +1242,6 @@ test-suite extra-native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1323,7 +1261,6 @@ test-suite extra-native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1343,7 +1280,6 @@ test-suite extra-native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas
@@ -1363,7 +1299,6 @@ test-suite extra-native :
                cxx11_defaulted_functions
                cxx11_final
                cxx11_hdr_mutex
-               cxx11_hdr_regex
                cxx11_hdr_thread
                cxx11_hdr_tuple
                cxx11_lambdas


### PR DESCRIPTION
This re-enables libstdc++ 4.8 by removing the `cxx11_hdr_regex` requirement everywhere except on `topology_test`, replacing it with a check in `topology.cpp`.