### PR TITLE
Most members of std::allocate are deprecated in C++17

### DIFF
--- a/include/boost/fiber/future/detail/shared_state_object.hpp
+++ b/include/boost/fiber/future/detail/shared_state_object.hpp
@@ -44,8 +44,9 @@ private:
 
     static void destroy_( allocator_type const& alloc, shared_state_object * p) noexcept {
         allocator_type a{ alloc };
-        a.destroy( p);
-        a.deallocate( p, 1);
+        typedef std::allocator_traits< allocator_type >    traity_type;
+        traity_type::destroy( a, p);
+        traity_type::deallocate( a, p, 1);
     }
 };
 

--- a/include/boost/fiber/future/detail/task_object.hpp
+++ b/include/boost/fiber/future/detail/task_object.hpp
@@ -33,9 +33,10 @@ template< typename Fn, typename Allocator, typename R, typename ... Args >
 class task_object : public task_base< R, Args ... > {
 private:
     typedef task_base< R, Args ... >    base_type;
+    typedef std::allocator_traits< Allocator >  allocator_traits;
 
 public:
-    typedef typename std::allocator_traits< Allocator >::template rebind_alloc< 
+    typedef typename allocator_traits::template rebind_alloc<
         task_object
     >                                           allocator_type;
 
@@ -93,8 +94,9 @@ private:
 
     static void destroy_( allocator_type const& alloc, task_object * p) noexcept {
         allocator_type a{ alloc };
-        a.destroy( p);
-        a.deallocate( p, 1);
+        typedef std::allocator_traits< allocator_type >    traity_type;
+        traity_type::destroy( a, p);
+        traity_type::deallocate( a, p, 1);
     }
 };
 
@@ -102,11 +104,12 @@ template< typename Fn, typename Allocator, typename ... Args >
 class task_object< Fn, Allocator, void, Args ... > : public task_base< void, Args ... > {
 private:
     typedef task_base< void, Args ... >    base_type;
+    typedef std::allocator_traits< Allocator >    allocator_traits;
 
 public:
-    typedef typename Allocator::template rebind<
+    typedef typename allocator_traits::template rebind_alloc<
         task_object< Fn, Allocator, void, Args ... >
-    >::other                                      allocator_type;
+    >                                             allocator_type;
 
     task_object( allocator_type const& alloc, Fn const& fn) :
         base_type{},
@@ -161,8 +164,9 @@ private:
 
     static void destroy_( allocator_type const& alloc, task_object * p) noexcept {
         allocator_type a{ alloc };
-        a.destroy( p);
-        a.deallocate( p, 1);
+        typedef std::allocator_traits< allocator_type >    traity_type;
+        traity_type::destroy( a, p);
+        traity_type::deallocate( a, p, 1);
     }
 };
 

--- a/test/test_async_dispatch.cpp
+++ b/test/test_async_dispatch.cpp
@@ -127,11 +127,12 @@ void test_async_stack_alloc() {
 }
 
 void test_async_std_alloc() {
+	struct none {};
     boost::fibers::future< void > f1 = boost::fibers::async(
             boost::fibers::launch::dispatch,
             std::allocator_arg,
             boost::fibers::fixedsize_stack{},
-            std::allocator< void >{},
+            std::allocator< none >{},
             fn1);
     BOOST_CHECK( f1.valid() );
 


### PR DESCRIPTION
And so is std::allocator<void>. Replace them by their cousins from std::allocator_traits. In addition to that, use std:allocator_traits wherever possible. Without that, heaps of deprecation warnings will fall onto humble users when compiling with MSVC 15 in C++17 mode.

Signed-off-by: Daniela Engert <dani@ngrt.de>