### PR TITLE
Really overwrite previous value when using boost::fibers::fiber_speci…

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -311,11 +311,7 @@ context::set_fss_data( void const * vp,
             i->second.do_cleanup();
         }
         if ( nullptr != data) {
-            fss_data_.insert(
-                    i,
-                    std::make_pair(
-                        key,
-                        fss_data{ data, cleanup_fn } ) );
+            i->second = fss_data{ data, cleanup_fn };
         } else {
             fss_data_.erase( i);
         }


### PR DESCRIPTION
…fic_ptr::reset(newValue).

Hi,

Today, when a fss has a non null value, and you call reset() on it, the new value doesn't overwrite the old one. This is caused by the fact that we std::map::insert which will never overwrite an existing key. This trivial fix should repair this.

Cheers,
Romain