### PR TITLE
Ignore unused argument warning with clang.

### DIFF
--- a/include/boost/fiber/context.hpp
+++ b/include/boost/fiber/context.hpp
@@ -20,6 +20,7 @@
 
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
+#include <boost/core/ignore_unused.hpp>
 #if defined(BOOST_NO_CXX17_STD_APPLY)
 #include <boost/context/detail/apply.hpp>
 #endif
@@ -426,6 +427,8 @@ private:
             auto arg = std::move( arg_);
 #if (defined(BOOST_USE_UCONTEXT)||defined(BOOST_USE_WINFIB))
             std::move( c).resume();
+#else
+            boost::ignore_unused(c);
 #endif
 #if defined(BOOST_NO_CXX17_STD_APPLY)
            boost::context::detail::apply( std::move( fn), std::move( arg) );


### PR DESCRIPTION
This fixes the following warning:

```
/remote/intdeliv/components/osp/Boost/18-0-0-6/include/boost/fiber/context.hpp:422:36: error: unused parameter 'c' [-Werror,-Wunused-parameter]
    run_( boost::context::fiber && c) {
                                   ^
1 error generated.
```