### PR TITLE
Assertion in scheduler.cpp with work_stealing algo and timed-out wait ops

### DIFF
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -387,7 +387,6 @@ scheduler::attach_worker_context( context * ctx) noexcept {
 #endif
     BOOST_ASSERT( ! ctx->sleep_is_linked() );
     BOOST_ASSERT( ! ctx->terminated_is_linked() );
-    BOOST_ASSERT( ! ctx->wait_is_linked() );
     BOOST_ASSERT( ! ctx->worker_is_linked() );
     ctx->worker_link( worker_queue_);
     ctx->scheduler_ = this;
@@ -403,7 +402,6 @@ scheduler::detach_worker_context( context * ctx) noexcept {
 #endif
     BOOST_ASSERT( ! ctx->sleep_is_linked() );
     BOOST_ASSERT( ! ctx->terminated_is_linked() );
-    BOOST_ASSERT( ! ctx->wait_is_linked() );
     BOOST_ASSERT( ctx->worker_is_linked() );
     BOOST_ASSERT( ! ctx->is_context( type::pinned_context) );
     ctx->worker_unlink();


### PR DESCRIPTION
I run into crashes in my application when using worker threads with the work_stealing scheduling algorithm and waits timing out on a buffered_channel.

It seems to be closely related to issue #166, but for a work_stealing scheduling algorithm. If requested, I could try and extract a minimal working example to reproduce this.