### PR TITLE
cpu_relax: Don't use pause for MIPS under rev 2

### DIFF
--- a/include/boost/fiber/detail/cpu_relax.hpp
+++ b/include/boost/fiber/detail/cpu_relax.hpp
@@ -47,7 +47,7 @@ namespace detail {
 # else
 #  define cpu_relax() asm volatile ("nop" ::: "memory");
 # endif
-#elif BOOST_ARCH_MIPS
+#elif BOOST_ARCH_MIPS > 1
 # define cpu_relax() asm volatile ("pause" ::: "memory");
 #elif BOOST_ARCH_PPC
 // http://code.metager.de/source/xref/gnu/glibc/sysdeps/powerpc/sys/platform/ppc.h


### PR DESCRIPTION
PAUSE was introduced in MIPS32r2.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Example of build failure: https://downloads.openwrt.org/snapshots/faillogs/mips_mips32/packages/boost/compile.txt

Ctrl+F error: will show

```
{standard input}:1942: Error: opcode not supported on this processor: mips32 (mips32) `pause'
{standard input}:2017: Error: opcode not supported on this processor: mips32 (mips32) `pause'
```