### PR TITLE
cpu_relax: Fix MIPS check

### DIFF
--- a/include/boost/fiber/detail/cpu_relax.hpp
+++ b/include/boost/fiber/detail/cpu_relax.hpp
@@ -47,7 +47,7 @@ namespace detail {
 # else
 #  define cpu_relax() asm volatile ("nop" ::: "memory");
 # endif
-#elif BOOST_ARCH_MIPS > 1
+#elif BOOST_ARCH_MIPS && (__mips_isa_rev > 1)
 # define cpu_relax() asm volatile ("pause" ::: "memory");
 #elif BOOST_ARCH_PPC
 // http://code.metager.de/source/xref/gnu/glibc/sysdeps/powerpc/sys/platform/ppc.h


### PR DESCRIPTION
BOOST_ARCH_MIPS as a macro is totally broken. It always gets defined to either 32
or 64 with a bunch of zeroes depending on the architecture.

Use GCC's internal define to check the architecture properly.

Signed-off-by: Rosen Penev <rosenp@gmail.com>