### PR TITLE
treewide: Fix operator++/operator-- const

### DIFF
--- a/include/boost/fiber/buffered_channel.hpp
+++ b/include/boost/fiber/buffered_channel.hpp
@@ -588,7 +588,7 @@ public:
             return * this;
         }
 
-        iterator operator++( int) = delete;
+        const iterator operator++( int) = delete;
 
         reference_t operator*() noexcept {
             return * reinterpret_cast< value_type * >( std::addressof( storage_) );

--- a/include/boost/fiber/unbuffered_channel.hpp
+++ b/include/boost/fiber/unbuffered_channel.hpp
@@ -636,7 +636,7 @@ public:
             return * this;
         }
 
-        iterator operator++( int) = delete;
+        const iterator operator++( int) = delete;
 
         reference_t operator*() noexcept {
             return * reinterpret_cast< value_type * >( std::addressof( storage_) );


### PR DESCRIPTION
Found with clang-tidy's cert-dcl21-cpp

Signed-off-by: Rosen Penev <rosenp@gmail.com>