### PR TITLE
properties: Use dynamic_cast for derived classes

### DIFF
--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -28,7 +28,7 @@ fiber_properties::notify() noexcept {
     // with a change to a fiber it's not currently tracking: it will do the
     // right thing next time the fiber is passed to its awakened() method.
     if ( ctx_->ready_is_linked() ) {
-        static_cast< algo::algorithm_with_properties_base * >( algo_)->
+        dynamic_cast< algo::algorithm_with_properties_base * >( algo_)->
             property_change_( ctx_, this);
     }
 }


### PR DESCRIPTION
Found with clang-tidy's cppcoreguidelines-pro-type-static-cast-downcast

Signed-off-by: Rosen Penev <rosenp@gmail.com>