### PR TITLE
treewide: Use std::move where appropriate

### DIFF
--- a/include/boost/fiber/context.hpp
+++ b/include/boost/fiber/context.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
@@ -151,9 +152,9 @@ private:
         }
 
         fss_data( void * vp_,
-                  detail::fss_cleanup_function::ptr_t const& fn) noexcept :
+                  detail::fss_cleanup_function::ptr_t fn) noexcept :
             vp( vp_),
-            cleanup_function( fn) {
+            cleanup_function(std::move( fn)) {
             BOOST_ASSERT( cleanup_function);
         }
 

--- a/include/boost/fiber/future/future.hpp
+++ b/include/boost/fiber/future/future.hpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <chrono>
 #include <exception>
+#include <utility>
 
 #include <boost/config.hpp>
 
@@ -30,8 +31,8 @@ struct future_base {
 
     future_base() = default;
 
-    explicit future_base( ptr_type const& p) noexcept :
-        state_{ p } {
+    explicit future_base( ptr_type  p) noexcept :
+        state_{std::move( p )} {
     }
 
     ~future_base() = default;


### PR DESCRIPTION
Found with modernize-pass-by-value

Signed-off-by: Rosen Penev <rosenp@gmail.com>