### PR TITLE
Fix error in documentation of buffered_channel::capacity().

### DIFF
--- a/doc/buffered_channel.qbk
+++ b/doc/buffered_channel.qbk
@@ -123,7 +123,7 @@ Class `buffered_channel` supports range-for syntax:
         explicit buffered_channel( std::size_t capacity);
 
 [variablelist
-[[Preconditions:] [`2<=capacity && 0==(capacity & (capacity-1))`]]
+[[Preconditions:] [`2>=capacity && 0==(capacity & (capacity-1))`]]
 [[Effects:] [The constructor constructs an object of class `buffered_channel`
 with an internal buffer of size `capacity`.]]
 [[Throws:] [`fiber_error`]]


### PR DESCRIPTION
The capacity bust be *at least 2*, not *at most 2*, as the documentation currently wrongly says.