### PR TITLE
treewide: Do not use else after return or throw

### DIFF
--- a/include/boost/fiber/context.hpp
+++ b/include/boost/fiber/context.hpp
@@ -242,9 +242,8 @@ public:
         operator<<( std::basic_ostream< charT, traitsT > & os, id const& other) {
             if ( nullptr != other.impl_) {
                 return os << other.impl_;
-            } else {
-                return os << "{not-valid}";
             }
+            return os << "{not-valid}";
         }
 
         explicit operator bool() const noexcept {
@@ -279,8 +278,7 @@ public:
     id get_id() const noexcept;
 
     bool is_resumable() const noexcept {
-        if ( c_) return true;
-        else return false;
+        return static_cast<bool>(c_);
     }
 
     void resume() noexcept;

--- a/include/boost/fiber/detail/thread_barrier.hpp
+++ b/include/boost/fiber/detail/thread_barrier.hpp
@@ -51,9 +51,8 @@ public:
             lk.unlock(); // no pessimization
             cond_.notify_all();
             return true;
-        } else {
-            cond_.wait( lk, [&](){ return cycle != cycle_; });
         }
+        cond_.wait( lk, [&](){ return cycle != cycle_; });
         return false;
     }
 };

--- a/include/boost/fiber/unbuffered_channel.hpp
+++ b/include/boost/fiber/unbuffered_channel.hpp
@@ -78,9 +78,8 @@ private:
                     continue;
                 }
                 return true;
-            } else {
-                return false;
             }
+            return false;
         }
     }
 
@@ -172,7 +171,8 @@ public:
                         // notify context
                         active_ctx->schedule( consumer_ctx);
                         break;
-                    } else if ( static_cast< std::intptr_t >( 0) == expected) {
+                    }
+                    if ( static_cast< std::intptr_t >( 0) == expected) {
                         // no timed-wait op.
                         // notify context
                         active_ctx->schedule( consumer_ctx);
@@ -185,24 +185,22 @@ public:
                 if ( nullptr == s.ctx) {
                     // value has been consumed
                     return channel_op_status::success;
-                } else {
-                    // channel was closed before value was consumed
-                    return channel_op_status::closed;
                 }
-            } else {
-                detail::spinlock_lock lk{ splk_producers_ };
-                if ( BOOST_UNLIKELY( is_closed() ) ) {
-                    return channel_op_status::closed;
-                }
-                if ( is_empty_() ) {
-                    continue;
-                }
-                active_ctx->wait_link( waiting_producers_);
-                active_ctx->twstatus.store( static_cast< std::intptr_t >( 0), std::memory_order_release);
-                // suspend this producer
-                active_ctx->suspend( lk);
-                // resumed, slot mabye free
+                // channel was closed before value was consumed
+                return channel_op_status::closed;
             }
+            detail::spinlock_lock lk{ splk_producers_ };
+            if ( BOOST_UNLIKELY( is_closed() ) ) {
+                return channel_op_status::closed;
+            }
+            if ( is_empty_() ) {
+                continue;
+            }
+            active_ctx->wait_link( waiting_producers_);
+            active_ctx->twstatus.store( static_cast< std::intptr_t >( 0), std::memory_order_release);
+            // suspend this producer
+            active_ctx->suspend( lk);
+            // resumed, slot mabye free
         }
     }
 
@@ -224,7 +222,7 @@ public:
                         // notify context
                         active_ctx->schedule( consumer_ctx);
                         break;
-                    } else if ( static_cast< std::intptr_t >( 0) == expected) {
+                    } if ( static_cast< std::intptr_t >( 0) == expected) {
                         // no timed-wait op.
                         // notify context
                         active_ctx->schedule( consumer_ctx);
@@ -237,24 +235,22 @@ public:
                 if ( nullptr == s.ctx) {
                     // value has been consumed
                     return channel_op_status::success;
-                } else {
-                    // channel was closed before value was consumed
-                    return channel_op_status::closed;
                 }
-            } else {
-                detail::spinlock_lock lk{ splk_producers_ };
-                if ( BOOST_UNLIKELY( is_closed() ) ) {
-                    return channel_op_status::closed;
-                }
-                if ( is_empty_() ) {
-                    continue;
-                }
-                active_ctx->wait_link( waiting_producers_);
-                active_ctx->twstatus.store( static_cast< std::intptr_t >( 0), std::memory_order_release);
-                // suspend this producer
-                active_ctx->suspend( lk);
-                // resumed, slot mabye free
+                // channel was closed before value was consumed
+                return channel_op_status::closed;
             }
+            detail::spinlock_lock lk{ splk_producers_ };
+            if ( BOOST_UNLIKELY( is_closed() ) ) {
+                return channel_op_status::closed;
+            }
+            if ( is_empty_() ) {
+                continue;
+            }
+            active_ctx->wait_link( waiting_producers_);
+            active_ctx->twstatus.store( static_cast< std::intptr_t >( 0), std::memory_order_release);
+            // suspend this producer
+            active_ctx->suspend( lk);
+            // resumed, slot mabye free
         }
     }
 
@@ -293,7 +289,8 @@ public:
                         // notify context
                         active_ctx->schedule( consumer_ctx);
                         break;
-                    } else if ( static_cast< std::intptr_t >( 0) == expected) {
+                    }
+                    if ( static_cast< std::intptr_t >( 0) == expected) {
                         // no timed-wait op.
                         // notify context
                         active_ctx->schedule( consumer_ctx);
@@ -313,30 +310,28 @@ public:
                 if ( nullptr == s.ctx) {
                     // value has been consumed
                     return channel_op_status::success;
-                } else {
-                    // channel was closed before value was consumed
-                    return channel_op_status::closed;
                 }
-            } else {
-                detail::spinlock_lock lk{ splk_producers_ };
-                if ( BOOST_UNLIKELY( is_closed() ) ) {
-                    return channel_op_status::closed;
-                }
-                if ( is_empty_() ) {
-                    continue;
-                }
-                active_ctx->wait_link( waiting_producers_);
-                active_ctx->twstatus.store( reinterpret_cast< std::intptr_t >( this), std::memory_order_release);
-                // suspend this producer
-                if ( ! active_ctx->wait_until( timeout_time, lk) ) {
-                    // relock local lk
-                    lk.lock();
-                    // remove from waiting-queue
-                    waiting_producers_.remove( * active_ctx);
-                    return channel_op_status::timeout;
-                }
-                // resumed, slot maybe free
+                // channel was closed before value was consumed
+                return channel_op_status::closed;
             }
+            detail::spinlock_lock lk{ splk_producers_ };
+            if ( BOOST_UNLIKELY( is_closed() ) ) {
+                return channel_op_status::closed;
+            }
+            if ( is_empty_() ) {
+                continue;
+            }
+            active_ctx->wait_link( waiting_producers_);
+            active_ctx->twstatus.store( reinterpret_cast< std::intptr_t >( this), std::memory_order_release);
+            // suspend this producer
+            if ( ! active_ctx->wait_until( timeout_time, lk) ) {
+                // relock local lk
+                lk.lock();
+                // remove from waiting-queue
+                waiting_producers_.remove( * active_ctx);
+                return channel_op_status::timeout;
+            }
+            // resumed, slot maybe free
         }
     }
 
@@ -361,7 +356,7 @@ public:
                         // notify context
                         active_ctx->schedule( consumer_ctx);
                         break;
-                    } else if ( static_cast< std::intptr_t >( 0) == expected) {
+                    } if ( static_cast< std::intptr_t >( 0) == expected) {
                         // no timed-wait op.
                         // notify context
                         active_ctx->schedule( consumer_ctx);
@@ -381,30 +376,28 @@ public:
                 if ( nullptr == s.ctx) {
                     // value has been consumed
                     return channel_op_status::success;
-                } else {
-                    // channel was closed before value was consumed
-                    return channel_op_status::closed;
                 }
-            } else {
-                detail::spinlock_lock lk{ splk_producers_ };
-                if ( BOOST_UNLIKELY( is_closed() ) ) {
-                    return channel_op_status::closed;
-                }
-                if ( is_empty_() ) {
-                    continue;
-                }
-                active_ctx->wait_link( waiting_producers_);
-                active_ctx->twstatus.store( reinterpret_cast< std::intptr_t >( this), std::memory_order_release);
-                // suspend this producer
-                if ( ! active_ctx->wait_until( timeout_time, lk) ) {
-                    // relock local lk
-                    lk.lock();
-                    // remove from waiting-queue
-                    waiting_producers_.remove( * active_ctx);
-                    return channel_op_status::timeout;
-                }
-                // resumed, slot maybe free
+                // channel was closed before value was consumed
+                return channel_op_status::closed;
             }
+            detail::spinlock_lock lk{ splk_producers_ };
+            if ( BOOST_UNLIKELY( is_closed() ) ) {
+                return channel_op_status::closed;
+            }
+            if ( is_empty_() ) {
+                continue;
+            }
+            active_ctx->wait_link( waiting_producers_);
+            active_ctx->twstatus.store( reinterpret_cast< std::intptr_t >( this), std::memory_order_release);
+            // suspend this producer
+            if ( ! active_ctx->wait_until( timeout_time, lk) ) {
+                // relock local lk
+                lk.lock();
+                // remove from waiting-queue
+                waiting_producers_.remove( * active_ctx);
+                return channel_op_status::timeout;
+            }
+            // resumed, slot maybe free
         }
     }
 
@@ -425,7 +418,7 @@ public:
                             // notify context
                             active_ctx->schedule( producer_ctx);
                             break;
-                        } else if ( static_cast< std::intptr_t >( 0) == expected) {
+                        } if ( static_cast< std::intptr_t >( 0) == expected) {
                             lk.unlock();
                             // no timed-wait op.
                             // notify context
@@ -442,20 +435,19 @@ public:
                 active_ctx->schedule( std::exchange( s->ctx, nullptr) );
 #endif
                 return channel_op_status::success;
-            } else {
-                detail::spinlock_lock lk{ splk_consumers_ };
-                if ( BOOST_UNLIKELY( is_closed() ) ) {
-                    return channel_op_status::closed;
-                }
-                if ( ! is_empty_() ) {
-                    continue;
-                }
-                active_ctx->wait_link( waiting_consumers_);
-                active_ctx->twstatus.store( static_cast< std::intptr_t >( 0), std::memory_order_release);
-                // suspend this consumer
-                active_ctx->suspend( lk);
-                // resumed, slot mabye set
             }
+            detail::spinlock_lock lk{ splk_consumers_ };
+            if ( BOOST_UNLIKELY( is_closed() ) ) {
+                return channel_op_status::closed;
+            }
+            if ( ! is_empty_() ) {
+                continue;
+            }
+            active_ctx->wait_link( waiting_consumers_);
+            active_ctx->twstatus.store( static_cast< std::intptr_t >( 0), std::memory_order_release);
+            // suspend this consumer
+            active_ctx->suspend( lk);
+            // resumed, slot mabye set
         }
     }
 
@@ -476,7 +468,7 @@ public:
                             // notify context
                             active_ctx->schedule( producer_ctx);
                             break;
-                        } else if ( static_cast< std::intptr_t >( 0) == expected) {
+                        } if ( static_cast< std::intptr_t >( 0) == expected) {
                             lk.unlock();
                             // no timed-wait op.
                             // notify context
@@ -494,22 +486,21 @@ public:
                 active_ctx->schedule( std::exchange( s->ctx, nullptr) );
 #endif
                 return std::move( value);
-            } else {
-                detail::spinlock_lock lk{ splk_consumers_ };
-                if ( BOOST_UNLIKELY( is_closed() ) ) {
-                    throw fiber_error{
-                            std::make_error_code( std::errc::operation_not_permitted),
-                            "boost fiber: channel is closed" };
-                }
-                if ( ! is_empty_() ) {
-                    continue;
-                }
-                active_ctx->wait_link( waiting_consumers_);
-                active_ctx->twstatus.store( static_cast< std::intptr_t >( 0), std::memory_order_release);
-                // suspend this consumer
-                active_ctx->suspend( lk);
-                // resumed, slot mabye set
             }
+            detail::spinlock_lock lk{ splk_consumers_ };
+            if ( BOOST_UNLIKELY( is_closed() ) ) {
+                throw fiber_error{
+                        std::make_error_code( std::errc::operation_not_permitted),
+                        "boost fiber: channel is closed" };
+            }
+            if ( ! is_empty_() ) {
+                continue;
+            }
+            active_ctx->wait_link( waiting_consumers_);
+            active_ctx->twstatus.store( static_cast< std::intptr_t >( 0), std::memory_order_release);
+            // suspend this consumer
+            active_ctx->suspend( lk);
+            // resumed, slot mabye set
         }
     }
 
@@ -540,7 +531,8 @@ public:
                             // notify context
                             active_ctx->schedule( producer_ctx);
                             break;
-                        } else if ( static_cast< std::intptr_t >( 0) == expected) {
+                        }
+                        if ( static_cast< std::intptr_t >( 0) == expected) {
                             lk.unlock();
                             // no timed-wait op.
                             // notify context
@@ -558,24 +550,23 @@ public:
                 active_ctx->schedule( std::exchange( s->ctx, nullptr) );
 #endif
                 return channel_op_status::success;
-            } else {
-                detail::spinlock_lock lk{ splk_consumers_ };
-                if ( BOOST_UNLIKELY( is_closed() ) ) {
-                    return channel_op_status::closed;
-                }
-                if ( ! is_empty_() ) {
-                    continue;
-                }
-                active_ctx->wait_link( waiting_consumers_);
-                active_ctx->twstatus.store( reinterpret_cast< std::intptr_t >( this), std::memory_order_release);
-                // suspend this consumer
-                if ( ! active_ctx->wait_until( timeout_time, lk) ) {
-                    // relock local lk
-                    lk.lock();
-                    // remove from waiting-queue
-                    waiting_consumers_.remove( * active_ctx);
-                    return channel_op_status::timeout;
-                }
+            }
+            detail::spinlock_lock lk{ splk_consumers_ };
+            if ( BOOST_UNLIKELY( is_closed() ) ) {
+                return channel_op_status::closed;
+            }
+            if ( ! is_empty_() ) {
+                continue;
+            }
+            active_ctx->wait_link( waiting_consumers_);
+            active_ctx->twstatus.store( reinterpret_cast< std::intptr_t >( this), std::memory_order_release);
+            // suspend this consumer
+            if ( ! active_ctx->wait_until( timeout_time, lk) ) {
+                // relock local lk
+                lk.lock();
+                // remove from waiting-queue
+                waiting_consumers_.remove( * active_ctx);
+                return channel_op_status::timeout;
             }
         }
     }

--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -37,9 +37,9 @@ barrier::wait() {
         lk.unlock(); // no pessimization
         cond_.notify_all();
         return true;
-    } else {
-        cond_.wait( lk, [&]{ return cycle != cycle_; });
     }
+
+    cond_.wait( lk, [&]{ return cycle != cycle_; });
     return false;
 }
 

--- a/src/condition_variable.cpp
+++ b/src/condition_variable.cpp
@@ -28,7 +28,8 @@ condition_variable_any::notify_one() noexcept {
             // notify context
             active_ctx->schedule( ctx);
             break;
-        } else if ( static_cast< std::intptr_t >( 0) == expected) {
+        }
+        if ( static_cast< std::intptr_t >( 0) == expected) {
             // no timed-wait op.
             // notify context
             active_ctx->schedule( ctx);

--- a/src/mutex.cpp
+++ b/src/mutex.cpp
@@ -30,7 +30,8 @@ mutex::lock() {
             throw lock_error{
                     std::make_error_code( std::errc::resource_deadlock_would_occur),
                     "boost fiber: a deadlock is detected" };
-        } else if ( nullptr == owner_) {
+        }
+        if ( nullptr == owner_) {
             owner_ = active_ctx;
             return;
         }
@@ -50,7 +51,8 @@ mutex::try_lock() {
         throw lock_error{
                 std::make_error_code( std::errc::resource_deadlock_would_occur),
                 "boost fiber: a deadlock is detected" };
-    } else if ( nullptr == owner_) {
+    }
+    if ( nullptr == owner_) {
         owner_ = active_ctx;
     }
     lk.unlock();

--- a/src/recursive_mutex.cpp
+++ b/src/recursive_mutex.cpp
@@ -28,7 +28,8 @@ recursive_mutex::lock() {
         if ( active_ctx == owner_) {
             ++count_;
             return;
-        } else if ( nullptr == owner_) {
+        }
+        if ( nullptr == owner_) {
             owner_ = active_ctx;
             count_ = 1;
             return;

--- a/src/recursive_timed_mutex.cpp
+++ b/src/recursive_timed_mutex.cpp
@@ -31,7 +31,8 @@ recursive_timed_mutex::try_lock_until_( std::chrono::steady_clock::time_point co
         if ( active_ctx == owner_) {
             ++count_;
             return true;
-        } else if ( nullptr == owner_) {
+        }
+        if ( nullptr == owner_) {
             owner_ = active_ctx;
             count_ = 1;
             return true;
@@ -59,7 +60,8 @@ recursive_timed_mutex::lock() {
         if ( active_ctx == owner_) {
             ++count_;
             return;
-        } else if ( nullptr == owner_) {
+        }
+        if ( nullptr == owner_) {
             owner_ = active_ctx;
             count_ = 1;
             return;

--- a/src/timed_mutex.cpp
+++ b/src/timed_mutex.cpp
@@ -56,7 +56,8 @@ timed_mutex::lock() {
             throw lock_error{
                     std::make_error_code( std::errc::resource_deadlock_would_occur),
                     "boost fiber: a deadlock is detected" };
-        } else if ( nullptr == owner_) {
+        }
+        if ( nullptr == owner_) {
             owner_ = active_ctx;
             return;
         }
@@ -77,7 +78,8 @@ timed_mutex::try_lock() {
         throw lock_error{
                 std::make_error_code( std::errc::resource_deadlock_would_occur),
                 "boost fiber: a deadlock is detected" };
-    } else if ( nullptr == owner_) {
+    }
+    if ( nullptr == owner_) {
         owner_ = active_ctx;
     }
     lk.unlock();


### PR DESCRIPTION
Found with clang-tidy's readability-else-after-return

Signed-off-by: Rosen Penev <rosenp@gmail.com>