### PR TITLE
treewide: Use auto where appropriate

### DIFF
--- a/include/boost/fiber/buffered_channel.hpp
+++ b/include/boost/fiber/buffered_channel.hpp
@@ -93,7 +93,7 @@ public:
             while ( ! waiting_producers_.empty() ) {
                 context * producer_ctx = & waiting_producers_.front();
                 waiting_producers_.pop_front();
-                std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                auto expected = reinterpret_cast< std::intptr_t >( this);
                 if ( producer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                     // notify context
                     active_ctx->schedule( producer_ctx);
@@ -107,7 +107,7 @@ public:
             while ( ! waiting_consumers_.empty() ) {
                 context * consumer_ctx = & waiting_consumers_.front();
                 waiting_consumers_.pop_front();
-                std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                auto expected = reinterpret_cast< std::intptr_t >( this);
                 if ( consumer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                     // notify context
                     active_ctx->schedule( consumer_ctx);
@@ -134,7 +134,7 @@ public:
             while ( ! waiting_consumers_.empty() ) {
                 context * consumer_ctx = & waiting_consumers_.front();
                 waiting_consumers_.pop_front();
-                std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                auto expected = reinterpret_cast< std::intptr_t >( this);
                 if ( consumer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                     lk.unlock();
                     // notify context
@@ -166,7 +166,7 @@ public:
             while ( ! waiting_consumers_.empty() ) {
                 context * consumer_ctx = & waiting_consumers_.front();
                 waiting_consumers_.pop_front();
-                std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                auto expected = reinterpret_cast< std::intptr_t >( this);
                 if ( consumer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                     lk.unlock();
                     // notify context
@@ -202,7 +202,7 @@ public:
                 while ( ! waiting_consumers_.empty() ) {
                     context * consumer_ctx = & waiting_consumers_.front();
                     waiting_consumers_.pop_front();
-                    std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                    auto expected = reinterpret_cast< std::intptr_t >( this);
                     if ( consumer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                         lk.unlock();
                         // notify context
@@ -239,7 +239,7 @@ public:
                 while ( ! waiting_consumers_.empty() ) {
                     context * consumer_ctx = & waiting_consumers_.front();
                     waiting_consumers_.pop_front();
-                    std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                    auto expected = reinterpret_cast< std::intptr_t >( this);
                     if ( consumer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                         lk.unlock();
                         // notify context
@@ -299,7 +299,7 @@ public:
                 while ( ! waiting_consumers_.empty() ) {
                     context * consumer_ctx = & waiting_consumers_.front();
                     waiting_consumers_.pop_front();
-                    std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                    auto expected = reinterpret_cast< std::intptr_t >( this);
                     if ( consumer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                         lk.unlock();
                         // notify context
@@ -345,7 +345,7 @@ public:
                 while ( ! waiting_consumers_.empty() ) {
                     context * consumer_ctx = & waiting_consumers_.front();
                     waiting_consumers_.pop_front();
-                    std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                    auto expected = reinterpret_cast< std::intptr_t >( this);
                     if ( consumer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                         lk.unlock();
                         // notify context
@@ -378,7 +378,7 @@ public:
             while ( ! waiting_producers_.empty() ) {
                 context * producer_ctx = & waiting_producers_.front();
                 waiting_producers_.pop_front();
-                std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                auto expected = reinterpret_cast< std::intptr_t >( this);
                 if ( producer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                     lk.unlock();
                     // notify context
@@ -416,7 +416,7 @@ public:
                 while ( ! waiting_producers_.empty() ) {
                     context * producer_ctx = & waiting_producers_.front();
                     waiting_producers_.pop_front();
-                    std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                    auto expected = reinterpret_cast< std::intptr_t >( this);
                     if ( producer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                         lk.unlock();
                         // notify context
@@ -457,7 +457,7 @@ public:
                 while ( ! waiting_producers_.empty() ) {
                     context * producer_ctx = & waiting_producers_.front();
                     waiting_producers_.pop_front();
-                    std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                    auto expected = reinterpret_cast< std::intptr_t >( this);
                     if ( producer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                         lk.unlock();
                         // notify context
@@ -512,7 +512,7 @@ public:
                 while ( ! waiting_producers_.empty() ) {
                     context * producer_ctx = & waiting_producers_.front();
                     waiting_producers_.pop_front();
-                    std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                    auto expected = reinterpret_cast< std::intptr_t >( this);
                     if ( producer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                         lk.unlock();
                         // notify context

--- a/include/boost/fiber/unbuffered_channel.hpp
+++ b/include/boost/fiber/unbuffered_channel.hpp
@@ -126,7 +126,7 @@ public:
             while ( ! waiting_producers_.empty() ) {
                 context * producer_ctx = & waiting_producers_.front();
                 waiting_producers_.pop_front();
-                std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                auto expected = reinterpret_cast< std::intptr_t >( this);
                 if ( producer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                     // notify context
                     active_ctx->schedule( producer_ctx);
@@ -141,7 +141,7 @@ public:
             while ( ! waiting_consumers_.empty() ) {
                 context * consumer_ctx = & waiting_consumers_.front();
                 waiting_consumers_.pop_front();
-                std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                auto expected = reinterpret_cast< std::intptr_t >( this);
                 if ( consumer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                     // notify context
                     active_ctx->schedule( consumer_ctx);
@@ -167,7 +167,7 @@ public:
                 while ( ! waiting_consumers_.empty() ) {
                     context * consumer_ctx = & waiting_consumers_.front();
                     waiting_consumers_.pop_front();
-                    std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                    auto expected = reinterpret_cast< std::intptr_t >( this);
                     if ( consumer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                         // notify context
                         active_ctx->schedule( consumer_ctx);
@@ -219,7 +219,7 @@ public:
                 while ( ! waiting_consumers_.empty() ) {
                     context * consumer_ctx = & waiting_consumers_.front();
                     waiting_consumers_.pop_front();
-                    std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                    auto expected = reinterpret_cast< std::intptr_t >( this);
                     if ( consumer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                         // notify context
                         active_ctx->schedule( consumer_ctx);
@@ -288,7 +288,7 @@ public:
                 while ( ! waiting_consumers_.empty() ) {
                     context * consumer_ctx = & waiting_consumers_.front();
                     waiting_consumers_.pop_front();
-                    std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                    auto expected = reinterpret_cast< std::intptr_t >( this);
                     if ( consumer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                         // notify context
                         active_ctx->schedule( consumer_ctx);
@@ -356,7 +356,7 @@ public:
                 while ( ! waiting_consumers_.empty() ) {
                     context * consumer_ctx = & waiting_consumers_.front();
                     waiting_consumers_.pop_front();
-                    std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                    auto expected = reinterpret_cast< std::intptr_t >( this);
                     if ( consumer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                         // notify context
                         active_ctx->schedule( consumer_ctx);
@@ -419,7 +419,7 @@ public:
                     while ( ! waiting_producers_.empty() ) {
                         context * producer_ctx = & waiting_producers_.front();
                         waiting_producers_.pop_front();
-                        std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                        auto expected = reinterpret_cast< std::intptr_t >( this);
                         if ( producer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                             lk.unlock();
                             // notify context
@@ -470,7 +470,7 @@ public:
                     while ( ! waiting_producers_.empty() ) {
                         context * producer_ctx = & waiting_producers_.front();
                         waiting_producers_.pop_front();
-                        std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                        auto expected = reinterpret_cast< std::intptr_t >( this);
                         if ( producer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                             lk.unlock();
                             // notify context
@@ -534,7 +534,7 @@ public:
                     while ( ! waiting_producers_.empty() ) {
                         context * producer_ctx = & waiting_producers_.front();
                         waiting_producers_.pop_front();
-                        std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+                        auto expected = reinterpret_cast< std::intptr_t >( this);
                         if ( producer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                             lk.unlock();
                             // notify context

--- a/src/condition_variable.cpp
+++ b/src/condition_variable.cpp
@@ -23,7 +23,7 @@ condition_variable_any::notify_one() noexcept {
     while ( ! wait_queue_.empty() ) {
         context * ctx = & wait_queue_.front();
         wait_queue_.pop_front();
-        std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+        auto expected = reinterpret_cast< std::intptr_t >( this);
         if ( ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
             // notify context
             active_ctx->schedule( ctx);
@@ -46,7 +46,7 @@ condition_variable_any::notify_all() noexcept {
     while ( ! wait_queue_.empty() ) {
         context * ctx = & wait_queue_.front();
         wait_queue_.pop_front();
-        std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+        auto expected = reinterpret_cast< std::intptr_t >( this);
         if ( ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
             // notify context
             active_ctx->schedule( ctx);

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -75,7 +75,7 @@ struct context_initializer {
             // main fiber context of this thread
             context * main_ctx = new main_context{};
             // scheduler of this thread
-            scheduler * sched = new scheduler{};
+            auto sched = new scheduler{};
             // attach main context to scheduler
             sched->attach_main_context( main_ctx);
             // create and attach dispatcher context to scheduler
@@ -293,8 +293,8 @@ context::schedule( context * ctx) noexcept {
 
 void *
 context::get_fss_data( void const * vp) const {
-    uintptr_t key = reinterpret_cast< uintptr_t >( vp);
-    fss_data_t::const_iterator i = fss_data_.find( key);
+    auto key = reinterpret_cast< uintptr_t >( vp);
+    auto i = fss_data_.find( key);
     return fss_data_.end() != i ? i->second.vp : nullptr;
 }
 
@@ -304,8 +304,8 @@ context::set_fss_data( void const * vp,
                        void * data,
                        bool cleanup_existing) {
     BOOST_ASSERT( cleanup_fn);
-    uintptr_t key = reinterpret_cast< uintptr_t >( vp);
-    fss_data_t::iterator i = fss_data_.find( key);
+    auto key = reinterpret_cast< uintptr_t >( vp);
+    auto i = fss_data_.find( key);
     if ( fss_data_.end() != i) {
         if( cleanup_existing) {
             i->second.do_cleanup();

--- a/src/recursive_timed_mutex.cpp
+++ b/src/recursive_timed_mutex.cpp
@@ -103,7 +103,7 @@ recursive_timed_mutex::unlock() {
         if ( ! wait_queue_.empty() ) {
             context * ctx = & wait_queue_.front();
             wait_queue_.pop_front();
-            std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+            auto expected = reinterpret_cast< std::intptr_t >( this);
             if ( ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
                 // notify context
                 active_ctx->schedule( ctx);

--- a/src/timed_mutex.cpp
+++ b/src/timed_mutex.cpp
@@ -99,7 +99,7 @@ timed_mutex::unlock() {
     if ( ! wait_queue_.empty() ) {
         context * ctx = & wait_queue_.front();
         wait_queue_.pop_front();
-        std::intptr_t expected = reinterpret_cast< std::intptr_t >( this);
+        auto expected = reinterpret_cast< std::intptr_t >( this);
         if ( ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
             // notify context
             active_ctx->schedule( ctx);


### PR DESCRIPTION
Found with clang-tidy's modernize-use-auto

Signed-off-by: Rosen Penev <rosenp@gmail.com>