### PR TITLE
treewide: Add ending namespace comments

### DIFF
--- a/include/boost/fiber/algo/algorithm.hpp
+++ b/include/boost/fiber/algo/algorithm.hpp
@@ -126,7 +126,9 @@ struct algorithm_with_properties : public algorithm_with_properties_base {
     }
 };
 
-}}}
+} // namespace algo
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/algo/round_robin.hpp
+++ b/include/boost/fiber/algo/round_robin.hpp
@@ -56,7 +56,9 @@ public:
     virtual void notify() noexcept;
 };
 
-}}}
+} // namespace algo
+} // namespace fibers
+} // namespace boost
 
 #ifdef _MSC_VER
 # pragma warning(pop)

--- a/include/boost/fiber/algo/shared_work.hpp
+++ b/include/boost/fiber/algo/shared_work.hpp
@@ -73,7 +73,9 @@ public:
 	void notify() noexcept;
 };
 
-}}}
+} // namespace algo
+} // namespace fibers
+} // namespace boost
 
 #ifdef _MSC_VER
 # pragma warning(pop)

--- a/include/boost/fiber/algo/work_stealing.hpp
+++ b/include/boost/fiber/algo/work_stealing.hpp
@@ -79,7 +79,9 @@ public:
     virtual void notify() noexcept;
 };
 
-}}}
+} // namespace algo
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/barrier.hpp
+++ b/include/boost/fiber/barrier.hpp
@@ -39,7 +39,8 @@ public:
     bool wait();
 };
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/buffered_channel.hpp
+++ b/include/boost/fiber/buffered_channel.hpp
@@ -614,7 +614,8 @@ end( buffered_channel< T > &) {
     return typename buffered_channel< T >::iterator();
 }
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/channel_op_status.hpp
+++ b/include/boost/fiber/channel_op_status.hpp
@@ -25,7 +25,8 @@ enum class channel_op_status {
     timeout
 };
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/condition_variable.hpp
+++ b/include/boost/fiber/condition_variable.hpp
@@ -252,7 +252,8 @@ public:
     }
 };
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef _MSC_VER
 # pragma warning(pop)

--- a/include/boost/fiber/context.hpp
+++ b/include/boost/fiber/context.hpp
@@ -128,7 +128,7 @@ typedef intrusive::slist_member_hook<
     >
 >                                       remote_ready_hook;
 
-}
+}  // namespace detail
 
 class BOOST_FIBERS_DECL context {
 public:
@@ -504,7 +504,9 @@ wait_functor::const_pointer wait_functor::to_value_ptr( wait_functor::const_hook
     return intrusive::get_parent_from_member< context >( n, & context::wait_hook_);
 }
 
-}}}
+}  // namespace detail
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef _MSC_VER
 # pragma warning(pop)

--- a/include/boost/fiber/detail/context_spinlock_queue.hpp
+++ b/include/boost/fiber/detail/context_spinlock_queue.hpp
@@ -109,7 +109,9 @@ public:
 	}
 };
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/detail/context_spmc_queue.hpp
+++ b/include/boost/fiber/detail/context_spmc_queue.hpp
@@ -188,7 +188,9 @@ public:
     }
 };
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #if BOOST_COMP_CLANG
 #pragma clang diagnostic pop

--- a/include/boost/fiber/detail/convert.hpp
+++ b/include/boost/fiber/detail/convert.hpp
@@ -34,7 +34,9 @@ std::chrono::steady_clock::time_point convert(
     return std::chrono::steady_clock::now() + ( timeout_time - Clock::now() );
 }
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/detail/cpu_relax.hpp
+++ b/include/boost/fiber/detail/cpu_relax.hpp
@@ -73,7 +73,9 @@ namespace detail {
   }
 #endif
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/detail/data.hpp
+++ b/include/boost/fiber/detail/data.hpp
@@ -45,7 +45,9 @@ struct data_t {
     }
 };
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/detail/decay_copy.hpp
+++ b/include/boost/fiber/detail/decay_copy.hpp
@@ -27,7 +27,9 @@ decay_copy( T && t) {
     return std::forward< T >( t);
 }
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/detail/disable_overload.hpp
+++ b/include/boost/fiber/detail/disable_overload.hpp
@@ -25,7 +25,9 @@ namespace detail {
 template< typename X, typename Y >
 using disable_overload = boost::context::detail::disable_overload< X, Y >;
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/detail/exchange.hpp
+++ b/include/boost/fiber/detail/exchange.hpp
@@ -27,7 +27,9 @@ T exchange( T & t, U && nv) {
     return ov;
 }
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/detail/fss.hpp
+++ b/include/boost/fiber/detail/fss.hpp
@@ -50,7 +50,9 @@ public:
     }
 };
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/detail/futex.hpp
+++ b/include/boost/fiber/detail/futex.hpp
@@ -56,6 +56,8 @@ int futex_wait( std::atomic< std::int32_t > * addr, std::int32_t x) {
 # warn "no futex support on this platform"
 #endif
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #endif // BOOST_FIBERS_DETAIL_FUTEX_H

--- a/include/boost/fiber/detail/is_all_same.hpp
+++ b/include/boost/fiber/detail/is_all_same.hpp
@@ -35,7 +35,9 @@ struct is_all_same< X, Y0 > {
     static constexpr bool value = std::is_same< X, Y0 >::value;
 };
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/detail/rtm.hpp
+++ b/include/boost/fiber/detail/rtm.hpp
@@ -85,7 +85,9 @@ bool rtm_test() noexcept {
     return result;
 }
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/detail/spinlock.hpp
+++ b/include/boost/fiber/detail/spinlock.hpp
@@ -75,7 +75,9 @@ using spinlock = spinlock_ttas;
 using spinlock_lock = std::unique_lock< spinlock >;
 #endif
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/detail/spinlock_rtm.hpp
+++ b/include/boost/fiber/detail/spinlock_rtm.hpp
@@ -121,6 +121,8 @@ public:
     }
 };
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #endif // BOOST_FIBERS_SPINLOCK_RTM_H

--- a/include/boost/fiber/detail/spinlock_status.hpp
+++ b/include/boost/fiber/detail/spinlock_status.hpp
@@ -16,6 +16,8 @@ enum class spinlock_status {
     unlocked
 };
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #endif // BOOST_FIBERS_SPINLOCK_STATUS_H

--- a/include/boost/fiber/detail/spinlock_ttas.hpp
+++ b/include/boost/fiber/detail/spinlock_ttas.hpp
@@ -111,6 +111,8 @@ public:
     }
 };
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #endif // BOOST_FIBERS_SPINLOCK_TTAS_H

--- a/include/boost/fiber/detail/spinlock_ttas_adaptive.hpp
+++ b/include/boost/fiber/detail/spinlock_ttas_adaptive.hpp
@@ -119,6 +119,8 @@ public:
     }
 };
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #endif // BOOST_FIBERS_SPINLOCK_TTAS_ADAPTIVE_H

--- a/include/boost/fiber/detail/spinlock_ttas_adaptive_futex.hpp
+++ b/include/boost/fiber/detail/spinlock_ttas_adaptive_futex.hpp
@@ -131,6 +131,8 @@ public:
     }
 };
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #endif // BOOST_FIBERS_SPINLOCK_TTAS_ADAPTIVE_FUTEX_H

--- a/include/boost/fiber/detail/spinlock_ttas_futex.hpp
+++ b/include/boost/fiber/detail/spinlock_ttas_futex.hpp
@@ -122,6 +122,8 @@ public:
     }
 };
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #endif // BOOST_FIBERS_spinlock_ttas_futex_FUTEX_H

--- a/include/boost/fiber/detail/thread_barrier.hpp
+++ b/include/boost/fiber/detail/thread_barrier.hpp
@@ -58,6 +58,8 @@ public:
     }
 };
 
-}}}
+} // namespace detail
+} // namespace fibers
+} // namespace boost
 
 #endif // BOOST_FIBER_DETAIL_THREAD_BARRIER_H

--- a/include/boost/fiber/exceptions.hpp
+++ b/include/boost/fiber/exceptions.hpp
@@ -67,7 +67,8 @@ enum class future_errc {
 BOOST_FIBERS_DECL
 std::error_category const& future_category() noexcept;
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 namespace std {
 
@@ -85,7 +86,7 @@ std::error_condition make_error_condition( boost::fibers::future_errc e) noexcep
     return std::error_condition{ static_cast< int >( e), boost::fibers::future_category() };
 }
 
-}
+}  // namespace std
 
 namespace boost {
 namespace fibers {
@@ -139,7 +140,8 @@ public:
     }
 };
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/fiber.hpp
+++ b/include/boost/fiber/fiber.hpp
@@ -168,7 +168,8 @@ void swap( fiber & l, fiber & r) noexcept {
     return l.swap( r);
 }
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef _MSC_VER
 # pragma warning(pop)

--- a/include/boost/fiber/fixedsize_stack.hpp
+++ b/include/boost/fiber/fixedsize_stack.hpp
@@ -24,7 +24,8 @@ using fixedsize_stack = boost::context::fixedsize_stack;
 using   default_stack = boost::context::default_stack;
 #endif
 
-}}
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/fss.hpp
+++ b/include/boost/fiber/fss.hpp
@@ -98,7 +98,8 @@ public:
     }
 };
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/mutex.hpp
+++ b/include/boost/fiber/mutex.hpp
@@ -57,7 +57,8 @@ public:
     void unlock();
 };
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef _MSC_VER
 # pragma warning(pop)

--- a/include/boost/fiber/numa/pin_thread.hpp
+++ b/include/boost/fiber/numa/pin_thread.hpp
@@ -28,7 +28,9 @@ void pin_thread( std::uint32_t, std::thread::native_handle_type);
 BOOST_FIBERS_DECL
 void pin_thread( std::uint32_t cpuid);
 
-}}}
+} // namespace numa
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 # include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/numa/topology.hpp
+++ b/include/boost/fiber/numa/topology.hpp
@@ -37,7 +37,9 @@ bool operator<( node const& lhs, node const& rhs) noexcept {
 BOOST_FIBERS_DECL
 std::vector< node > topology();
 
-}}}
+} // namespace numa
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 # include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/operations.hpp
+++ b/include/boost/fiber/operations.hpp
@@ -68,7 +68,7 @@ PROPS & properties() {
     return dynamic_cast< PROPS & >( * props );
 }
 
-}
+}  // namespace this_fiber
 
 namespace fibers {
 
@@ -83,7 +83,8 @@ void use_scheduling_algorithm( Args && ... args) noexcept {
         ->set_algo( new SchedAlgo( std::forward< Args >( args) ... ) );
 }
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/policy.hpp
+++ b/include/boost/fiber/policy.hpp
@@ -35,9 +35,10 @@ template<>
 struct is_launch_policy< boost::fibers::launch > : public std::true_type {
 };
 
-}
+}  // namespace detail
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/pooled_fixedsize_stack.hpp
+++ b/include/boost/fiber/pooled_fixedsize_stack.hpp
@@ -21,7 +21,8 @@ namespace fibers {
 
 using pooled_fixedsize_stack = boost::context::pooled_fixedsize_stack;
 
-}}
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/properties.hpp
+++ b/include/boost/fiber/properties.hpp
@@ -30,7 +30,7 @@ namespace algo {
 
 class algorithm;
 
-}
+} // namespace algo
 
 class BOOST_FIBERS_DECL fiber_properties {
 protected:
@@ -66,7 +66,8 @@ public:
     }
 };
 
-}} // namespace boost::fibers
+}  // namespace fibers
+}  // namespace boost
 
 # if defined(BOOST_MSVC)
 # pragma warning(pop)

--- a/include/boost/fiber/protected_fixedsize_stack.hpp
+++ b/include/boost/fiber/protected_fixedsize_stack.hpp
@@ -21,7 +21,8 @@ namespace fibers {
 
 using protected_fixedsize_stack = boost::context::protected_fixedsize_stack;
 
-}}
+} // namespace fibers
+} // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/recursive_mutex.hpp
+++ b/include/boost/fiber/recursive_mutex.hpp
@@ -63,7 +63,8 @@ public:
     void unlock();
 };
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef _MSC_VER
 # pragma warning(pop)

--- a/include/boost/fiber/recursive_timed_mutex.hpp
+++ b/include/boost/fiber/recursive_timed_mutex.hpp
@@ -78,7 +78,8 @@ public:
     void unlock();
 };
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef _MSC_VER
 # pragma warning(pop)

--- a/include/boost/fiber/scheduler.hpp
+++ b/include/boost/fiber/scheduler.hpp
@@ -150,7 +150,8 @@ public:
     void detach_worker_context( context *) noexcept;
 };
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef _MSC_VER
 # pragma warning(pop)

--- a/include/boost/fiber/segmented_stack.hpp
+++ b/include/boost/fiber/segmented_stack.hpp
@@ -26,7 +26,8 @@ using default_stack = boost::context::default_stack;
 # endif
 #endif
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/timed_mutex.hpp
+++ b/include/boost/fiber/timed_mutex.hpp
@@ -72,7 +72,8 @@ public:
     void unlock();
 };
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef _MSC_VER
 # pragma warning(pop)

--- a/include/boost/fiber/type.hpp
+++ b/include/boost/fiber/type.hpp
@@ -97,7 +97,8 @@ operator^=( type & l, type r) {
     return l;
 }
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/include/boost/fiber/unbuffered_channel.hpp
+++ b/include/boost/fiber/unbuffered_channel.hpp
@@ -662,7 +662,8 @@ end( unbuffered_channel< T > &) {
     return typename unbuffered_channel< T >::iterator();
 }
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/src/algo/algorithm.cpp
+++ b/src/algo/algorithm.cpp
@@ -28,7 +28,9 @@ algorithm_with_properties_base::set_properties( context * ctx, fiber_properties 
     ctx->set_properties( props);
 }
 
-}}}
+}  // namespace algo
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/src/algo/round_robin.cpp
+++ b/src/algo/round_robin.cpp
@@ -65,7 +65,9 @@ round_robin::notify() noexcept {
     cnd_.notify_all();
 }
 
-}}}
+}  // namespace algo
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/src/algo/shared_work.cpp
+++ b/src/algo/shared_work.cpp
@@ -94,7 +94,9 @@ shared_work::notify() noexcept {
 shared_work::rqueue_type shared_work::rqueue_{};
 std::mutex shared_work::rqueue_mtx_{};
 
-}}}
+}  // namespace algo
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/src/algo/work_stealing.cpp
+++ b/src/algo/work_stealing.cpp
@@ -113,7 +113,9 @@ work_stealing::notify() noexcept {
     }
 }
 
-}}}
+}  // namespace algo
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/src/barrier.cpp
+++ b/src/barrier.cpp
@@ -43,7 +43,8 @@ barrier::wait() {
     return false;
 }
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/src/condition_variable.cpp
+++ b/src/condition_variable.cpp
@@ -58,7 +58,8 @@ condition_variable_any::notify_all() noexcept {
     }
 }
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -395,7 +395,8 @@ context::attach( context * ctx) noexcept {
     get_scheduler()->attach_worker_context( ctx);
 }
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/src/fiber.cpp
+++ b/src/fiber.cpp
@@ -64,7 +64,8 @@ fiber::detach() {
     impl_.reset();
 }
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/src/future.cpp
+++ b/src/future.cpp
@@ -68,4 +68,5 @@ std::error_category const& future_category() noexcept {
     return cat;
 }
 
-}}
+}  // namespace fibers
+}  // namespace boost

--- a/src/mutex.cpp
+++ b/src/mutex.cpp
@@ -76,7 +76,8 @@ mutex::unlock() {
     }
 }
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/src/numa/pin_thread.cpp
+++ b/src/numa/pin_thread.cpp
@@ -39,7 +39,9 @@ void pin_thread( std::uint32_t cpuid, std::thread::native_handle_type h) {
             "boost fiber: pin_thread() not supported" };
 }
 
-}}}
+}  // namespace numa
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 # include BOOST_ABI_SUFFIX

--- a/src/numa/topology.cpp
+++ b/src/numa/topology.cpp
@@ -33,7 +33,9 @@ std::vector< node > topology() {
     return std::vector< node >{};
 }
 
-}}}
+}  // namespace numa
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 # include BOOST_ABI_SUFFIX

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -33,7 +33,8 @@ fiber_properties::notify() noexcept {
     }
 }
 
-}}                                  // boost::fibers
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/src/recursive_mutex.cpp
+++ b/src/recursive_mutex.cpp
@@ -76,7 +76,8 @@ recursive_mutex::unlock() {
     }
 }
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/src/recursive_timed_mutex.cpp
+++ b/src/recursive_timed_mutex.cpp
@@ -116,7 +116,8 @@ recursive_timed_mutex::unlock() {
     }
 }
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -412,7 +412,8 @@ scheduler::detach_worker_context( context * ctx) noexcept {
     // a detached context must not belong to any queue
 }
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX

--- a/src/timed_mutex.cpp
+++ b/src/timed_mutex.cpp
@@ -111,7 +111,8 @@ timed_mutex::unlock() {
     }
 }
 
-}}
+}  // namespace fibers
+}  // namespace boost
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX


### PR DESCRIPTION
Found with clang-tidy's google-readability-namespace-comments

Signed-off-by: Rosen Penev <rosenp@gmail.com>