### PR TITLE
future: Use override instead of virtual

### DIFF
--- a/include/boost/fiber/algo/algorithm.hpp
+++ b/include/boost/fiber/algo/algorithm.hpp
@@ -79,7 +79,7 @@ struct algorithm_with_properties : public algorithm_with_properties_base {
     // must override awakened() with properties parameter instead. Otherwise
     // you'd have to remember to start every subclass awakened() override
     // with: algorithm_with_properties<PROPS>::awakened(fb);
-    virtual void awakened( context * ctx) noexcept override final {
+    void awakened( context * ctx) noexcept final {
         fiber_properties * props = super::get_properties( ctx);
         if ( BOOST_LIKELY( nullptr == props) ) {
             // TODO: would be great if PROPS could be allocated on the new
@@ -114,7 +114,7 @@ struct algorithm_with_properties : public algorithm_with_properties_base {
     }
 
     // implementation for algorithm_with_properties_base method
-    void property_change_( context * ctx, fiber_properties * props) noexcept override final {
+    void property_change_( context * ctx, fiber_properties * props) noexcept final {
         property_change( ctx, * static_cast< PROPS * >( props) );
     }
 

--- a/include/boost/fiber/algo/round_robin.hpp
+++ b/include/boost/fiber/algo/round_robin.hpp
@@ -45,15 +45,15 @@ public:
     round_robin( round_robin const&) = delete;
     round_robin & operator=( round_robin const&) = delete;
 
-    virtual void awakened( context *) noexcept;
+    void awakened( context *) noexcept override;
 
-    virtual context * pick_next() noexcept;
+    context * pick_next() noexcept override;
 
-    virtual bool has_ready_fibers() const noexcept;
+    bool has_ready_fibers() const noexcept override;
 
-    virtual void suspend_until( std::chrono::steady_clock::time_point const&) noexcept;
+    void suspend_until( std::chrono::steady_clock::time_point const&) noexcept override;
 
-    virtual void notify() noexcept;
+    void notify() noexcept override;
 };
 
 }}}

--- a/include/boost/fiber/algo/shared_work.hpp
+++ b/include/boost/fiber/algo/shared_work.hpp
@@ -59,18 +59,18 @@ public:
 	shared_work & operator=( shared_work const&) = delete;
 	shared_work & operator=( shared_work &&) = delete;
 
-    void awakened( context * ctx) noexcept;
+    void awakened( context * ctx) noexcept override;
 
-    context * pick_next() noexcept;
+    context * pick_next() noexcept override;
 
-    bool has_ready_fibers() const noexcept {
+    bool has_ready_fibers() const noexcept override {
         std::unique_lock< std::mutex > lock{ rqueue_mtx_ };
         return ! rqueue_.empty() || ! lqueue_.empty();
     }
 
-	void suspend_until( std::chrono::steady_clock::time_point const& time_point) noexcept;
+	void suspend_until( std::chrono::steady_clock::time_point const& time_point) noexcept override;
 
-	void notify() noexcept;
+	void notify() noexcept override;
 };
 
 }}}

--- a/include/boost/fiber/algo/work_stealing.hpp
+++ b/include/boost/fiber/algo/work_stealing.hpp
@@ -62,21 +62,21 @@ public:
     work_stealing & operator=( work_stealing const&) = delete;
     work_stealing & operator=( work_stealing &&) = delete;
 
-    virtual void awakened( context *) noexcept;
+    void awakened( context *) noexcept override;
 
-    virtual context * pick_next() noexcept;
+    context * pick_next() noexcept override;
 
     virtual context * steal() noexcept {
         return rqueue_.steal();
     }
 
-    virtual bool has_ready_fibers() const noexcept {
+    bool has_ready_fibers() const noexcept override {
         return ! rqueue_.empty();
     }
 
-    virtual void suspend_until( std::chrono::steady_clock::time_point const&) noexcept;
+    void suspend_until( std::chrono::steady_clock::time_point const&) noexcept override;
 
-    virtual void notify() noexcept;
+    void notify() noexcept override;
 };
 
 }}}

--- a/include/boost/fiber/exceptions.hpp
+++ b/include/boost/fiber/exceptions.hpp
@@ -39,7 +39,7 @@ public:
         std::system_error{ ec, what_arg } {
     }
 
-    virtual ~fiber_error() = default;
+    ~fiber_error() override = default;
 };
 
 class lock_error : public fiber_error {

--- a/include/boost/fiber/fss.hpp
+++ b/include/boost/fiber/fss.hpp
@@ -25,7 +25,7 @@ template< typename T >
 class fiber_specific_ptr {
 private:
     struct default_cleanup_function : public detail::fss_cleanup_function {
-        void operator()( void * data) noexcept {
+        void operator()( void * data) noexcept override {
             delete static_cast< T * >( data);
         }
     };
@@ -37,7 +37,7 @@ private:
             fn{ fn_ } {
         }
 
-        void operator()( void * data) {
+        void operator()( void * data) override {
             if ( BOOST_LIKELY( nullptr != fn) ) {
                 fn( static_cast< T * >( data) );
             }

--- a/src/future.cpp
+++ b/src/future.cpp
@@ -11,11 +11,11 @@ namespace fibers {
 
 class future_error_category : public std::error_category {
 public:
-    virtual const char* name() const noexcept {
+    const char* name() const noexcept override {
         return "fiber-future";
     }
 
-    virtual std::error_condition default_error_condition( int ev) const noexcept {
+    std::error_condition default_error_condition( int ev) const noexcept override {
         switch ( static_cast< future_errc >( ev) ) {
             case future_errc::broken_promise:
                 return std::error_condition{
@@ -39,12 +39,12 @@ public:
         }
     }
 
-    virtual bool equivalent( std::error_code const& code, int condition) const noexcept {
+    bool equivalent( std::error_code const& code, int condition) const noexcept override {
         return * this == code.category() &&
             static_cast< int >( default_error_condition( code.value() ).value() ) == condition;
     }
 
-    virtual std::string message( int ev) const {
+    std::string message( int ev) const override {
         switch ( static_cast< future_errc >( ev) ) {
             case future_errc::broken_promise:
                 return std::string{ "The associated promise has been destructed prior "


### PR DESCRIPTION
Found with clang-tidy's cppcoreguidelines-explicit-virtual-functions

Signed-off-by: Rosen Penev <rosenp@gmail.com>