### PR TITLE
treewide: Add explicit to single argument constructors

### DIFF
--- a/include/boost/fiber/exceptions.hpp
+++ b/include/boost/fiber/exceptions.hpp
@@ -27,7 +27,7 @@ namespace fibers {
 
 class fiber_error : public std::system_error {
 public:
-    fiber_error( std::error_code ec) :
+    explicit fiber_error( std::error_code ec) :
         std::system_error{ ec } {
     }
 
@@ -44,7 +44,7 @@ public:
 
 class lock_error : public fiber_error {
 public:
-    lock_error( std::error_code ec) :
+    explicit lock_error( std::error_code ec) :
         fiber_error{ ec } {
     }
 
@@ -92,7 +92,7 @@ namespace fibers {
 
 class future_error : public fiber_error {
 public:
-    future_error( std::error_code ec) :
+    explicit future_error( std::error_code ec) :
         fiber_error{ ec } {
     }
 };

--- a/include/boost/fiber/fiber.hpp
+++ b/include/boost/fiber/fiber.hpp
@@ -59,7 +59,7 @@ public:
               typename = detail::disable_overload< std::allocator_arg_t, Fn >
     >
 #if BOOST_COMP_GNUC < 50000000
-    fiber( Fn && fn, Arg && ... arg) :
+    explicit fiber( Fn && fn, Arg && ... arg) :
 #else
     fiber( Fn && fn, Arg ... arg) :
 #endif

--- a/include/boost/fiber/properties.hpp
+++ b/include/boost/fiber/properties.hpp
@@ -50,7 +50,7 @@ public:
 
     // fiber_properties, and by implication every subclass, must accept a back
     // pointer to its context.
-    fiber_properties( context * ctx) noexcept :
+    explicit fiber_properties( context * ctx) noexcept :
         ctx_{ ctx } {
     }
 


### PR DESCRIPTION
Found with clang-tidy's google-explicit-constructor

Signed-off-by: Rosen Penev <rosenp@gmail.com>