### PR TITLE
treewide: Replace {} with = equals

### DIFF
--- a/include/boost/fiber/algo/algorithm.hpp
+++ b/include/boost/fiber/algo/algorithm.hpp
@@ -35,7 +35,7 @@ private:
 public:
     typedef intrusive_ptr< algorithm >  ptr_t;
 
-    virtual ~algorithm() {}
+    virtual ~algorithm() = default;
 
     virtual void awakened( context *) noexcept = 0;
 

--- a/include/boost/fiber/context.hpp
+++ b/include/boost/fiber/context.hpp
@@ -148,8 +148,7 @@ private:
         void                                *   vp{ nullptr };
         detail::fss_cleanup_function::ptr_t     cleanup_function{};
 
-        fss_data() noexcept {
-        }
+        fss_data() noexcept = default;
 
         fss_data( void * vp_,
                   detail::fss_cleanup_function::ptr_t fn) noexcept :

--- a/include/boost/fiber/unbuffered_channel.hpp
+++ b/include/boost/fiber/unbuffered_channel.hpp
@@ -96,8 +96,7 @@ private:
     }
 
 public:
-    unbuffered_channel() {
-    }
+    unbuffered_channel() = default;
 
     ~unbuffered_channel() {
         close();


### PR DESCRIPTION
Found with modernize-use-equals-default

Signed-off-by: Rosen Penev <rosenp@gmail.com>