### PR TITLE
Speed up properties a bit

### DIFF
--- a/include/boost/fiber/algo/algorithm.hpp
+++ b/include/boost/fiber/algo/algorithm.hpp
@@ -81,14 +81,14 @@ struct algorithm_with_properties : public algorithm_with_properties_base {
     // with: algorithm_with_properties<PROPS>::awakened(fb);
     void awakened( context * ctx) noexcept final {
         fiber_properties * props = super::get_properties( ctx);
-        if ( BOOST_LIKELY( nullptr == props) ) {
+        if ( BOOST_UNLIKELY( nullptr == props) ) {
             // TODO: would be great if PROPS could be allocated on the new
             // fiber's stack somehow
             props = new_properties( ctx);
             // It is not good for new_properties() to return 0.
             BOOST_ASSERT_MSG( props, "new_properties() must return non-NULL");
             // new_properties() must return instance of (a subclass of) PROPS
-            BOOST_ASSERT_MSG( dynamic_cast< PROPS * >( props),
+            BOOST_ASSERT_MSG( template PROPS::typename downcaster< PROPS * >()( props),
                               "new_properties() must return properties class");
             super::set_properties( ctx, props);
         }

--- a/include/boost/fiber/fiber.hpp
+++ b/include/boost/fiber/fiber.hpp
@@ -154,7 +154,7 @@ public:
     PROPS & properties() {
         auto props = impl_->get_properties();
         BOOST_ASSERT_MSG( props, "fiber::properties not set");
-        return dynamic_cast< PROPS & >( * props );
+        return template PROPS::typename downcaster< PROPS & >()( * props );
     }
 };
 

--- a/include/boost/fiber/operations.hpp
+++ b/include/boost/fiber/operations.hpp
@@ -52,7 +52,7 @@ void sleep_for( std::chrono::duration< Rep, Period > const& timeout_duration) {
 template< typename PROPS >
 PROPS & properties() {
     fibers::fiber_properties * props = fibers::context::active()->get_properties();
-    if ( BOOST_LIKELY( nullptr == props) ) {
+    if ( BOOST_UNLIKELY( nullptr == props) ) {
         // props could be nullptr if the thread's main fiber has not yet
         // yielded (not yet passed through algorithm_with_properties::
         // awakened()). Address that by yielding right now.
@@ -65,7 +65,7 @@ PROPS & properties() {
         // algorithm_with_properties.
         BOOST_ASSERT_MSG( props, "this_fiber::properties not set");
     }
-    return dynamic_cast< PROPS & >( * props );
+    return template PROPS::typename downcaster< PROPS & >()( * props );
 }
 
 }

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -28,8 +28,7 @@ fiber_properties::notify() noexcept {
     // with a change to a fiber it's not currently tracking: it will do the
     // right thing next time the fiber is passed to its awakened() method.
     if ( ctx_->ready_is_linked() ) {
-        dynamic_cast< algo::algorithm_with_properties_base * >( algo_)->
-            property_change_( ctx_, this);
+        algo_->property_change_( ctx_, this);
     }
 }
 


### PR DESCRIPTION
 - It's unlikely that properties are null, it is null only the very
   first time the fiber is scheduled.
 - We don't need the dynamic_cast in notify, we can already use the
   right type, since it is used only with algorithm_with_properties
   anyway.
 - Allow user defined properties to specify they don't want to use
   dynamic_cast but they prefer static_cast for performance reason
   (and then it's their responsibility to ensure the types are ok).