### PR TITLE
Examples/fix asio deprecations

### DIFF
--- a/examples/asio/autoecho.cpp
+++ b/examples/asio/autoecho.cpp
@@ -153,11 +153,11 @@ void session( socket_ptr sock) {
 /*****************************************************************************
 *   listening server
 *****************************************************************************/
-void server( std::shared_ptr< boost::asio::io_service > const& io_svc, tcp::acceptor & a) {
+void server( std::shared_ptr< boost::asio::io_context > const& io_ctx, tcp::acceptor & a) {
     print( tag(), ": echo-server started");
     try {
         for (;;) {
-            socket_ptr socket( new tcp::socket( * io_svc) );
+            socket_ptr socket( new tcp::socket( * io_ctx) );
             boost::system::error_code ec;
             a.async_accept(
                     * socket,
@@ -171,21 +171,21 @@ void server( std::shared_ptr< boost::asio::io_service > const& io_svc, tcp::acce
     } catch ( std::exception const& ex) {
         print( tag(), ": caught exception : ", ex.what());
     }
-    io_svc->stop();
+    io_ctx->stop();
     print( tag(), ": echo-server stopped");
 }
 
 /*****************************************************************************
 *   fiber function per client
 *****************************************************************************/
-void client( std::shared_ptr< boost::asio::io_service > const& io_svc, tcp::acceptor & a,
+void client( std::shared_ptr< boost::asio::io_context > const& io_ctx, tcp::acceptor & a,
              boost::fibers::barrier& barrier, unsigned iterations) {
     print( tag(), ": echo-client started");
     for (unsigned count = 0; count < iterations; ++count) {
-        tcp::resolver resolver( * io_svc);
+        tcp::resolver resolver( * io_ctx);
         tcp::resolver::query query( tcp::v4(), "127.0.0.1", "9999");
         tcp::resolver::iterator iterator = resolver.resolve( query);
-        tcp::socket s( * io_svc);
+        tcp::socket s( * io_ctx);
         boost::asio::connect( s, iterator);
         for (unsigned msg = 0; msg < 1; ++msg) {
             std::ostringstream msgbuf;
@@ -230,27 +230,27 @@ void client( std::shared_ptr< boost::asio::io_service > const& io_svc, tcp::acce
 int main( int argc, char* argv[]) {
     try {
 //[asio_rr_setup
-        std::shared_ptr< boost::asio::io_service > io_svc = std::make_shared< boost::asio::io_service >();
-        boost::fibers::use_scheduling_algorithm< boost::fibers::asio::round_robin >( io_svc);
+        std::shared_ptr< boost::asio::io_context > io_ctx = std::make_shared< boost::asio::io_context >();
+        boost::fibers::use_scheduling_algorithm< boost::fibers::asio::round_robin >( io_ctx);
 //]
         print( "Thread ", thread_names.lookup(), ": started");
 //[asio_rr_launch_fibers
         // server
-        tcp::acceptor a( * io_svc, tcp::endpoint( tcp::v4(), 9999) );
-        boost::fibers::fiber( server, io_svc, std::ref( a) ).detach();
+        tcp::acceptor a( * io_ctx, tcp::endpoint( tcp::v4(), 9999) );
+        boost::fibers::fiber( server, io_ctx, std::ref( a) ).detach();
         // client
         const unsigned iterations = 2;
         const unsigned clients = 3;
         boost::fibers::barrier b( clients);
         for ( unsigned i = 0; i < clients; ++i) {
             boost::fibers::fiber(
-                    client, io_svc, std::ref( a), std::ref( b), iterations).detach();
+                    client, io_ctx, std::ref( a), std::ref( b), iterations).detach();
         }
 //]
 //[asio_rr_run
-        io_svc->run();
+        io_ctx->run();
 //]
-        print( tag(), ": io_service returned");
+        print( tag(), ": io_context returned");
         print( "Thread ", thread_names.lookup(), ": stopping");
         std::cout << "done." << std::endl;
         return EXIT_SUCCESS;

--- a/examples/asio/exchange.cpp
+++ b/examples/asio/exchange.cpp
@@ -15,7 +15,7 @@
 std::shared_ptr< boost::fibers::unbuffered_channel< int > > c;
 
 void foo() {
-    auto io_ptr = std::make_shared< boost::asio::io_service >();
+    auto io_ptr = std::make_shared< boost::asio::io_context >();
     boost::fibers::use_scheduling_algorithm< boost::fibers::asio::round_robin >( io_ptr);
     boost::fibers::fiber([io_ptr](){
         for ( int i = 0; i < 10; ++i) {
@@ -29,7 +29,7 @@ void foo() {
 }
 
 void bar() {
-    auto io_ptr = std::make_shared< boost::asio::io_service >();
+    auto io_ptr = std::make_shared< boost::asio::io_context >();
     boost::fibers::use_scheduling_algorithm< boost::fibers::asio::round_robin >( io_ptr);
     boost::fibers::fiber([io_ptr](){
         try {

--- a/examples/asio/ps/publisher.cpp
+++ b/examples/asio/ps/publisher.cpp
@@ -26,11 +26,11 @@ int main( int argc, char* argv[]) {
             std::cerr << "Usage: publisher <host> <queue>\n";
             return EXIT_FAILURE;
         }
-        boost::asio::io_service io_service;
-        tcp::resolver resolver( io_service);
+        boost::asio::io_context io_context;
+        tcp::resolver resolver( io_context);
         tcp::resolver::query query( tcp::v4(), argv[1], "9997");
         tcp::resolver::iterator iterator = resolver.resolve(query);
-        tcp::socket s( io_service);
+        tcp::socket s( io_context);
         boost::asio::connect( s, iterator);
         char msg[max_length];
         std::string queue( argv[2]);

--- a/examples/asio/ps/subscriber.cpp
+++ b/examples/asio/ps/subscriber.cpp
@@ -26,11 +26,11 @@ int main( int argc, char* argv[]) {
             std::cerr << "Usage: subscriber <host> <queue>\n";
             return EXIT_FAILURE;
         }
-        boost::asio::io_service io_service;
-        tcp::resolver resolver( io_service);
+        boost::asio::io_context io_context;
+        tcp::resolver resolver( io_context);
         tcp::resolver::query query( tcp::v4(), argv[1], "9998");
         tcp::resolver::iterator iterator = resolver.resolve( query);
-        tcp::socket s( io_service);
+        tcp::socket s( io_context);
         boost::asio::connect( s, iterator);
         char msg[max_length];
         std::string queue( argv[2]);

--- a/examples/asio/round_robin.hpp
+++ b/examples/asio/round_robin.hpp
@@ -36,7 +36,7 @@ namespace asio {
 class round_robin : public algo::algorithm {
 private:
 //[asio_rr_suspend_timer
-    std::shared_ptr< boost::asio::io_service >      io_svc_;
+    std::shared_ptr< boost::asio::io_context >      io_ctx_;
     boost::asio::steady_timer                       suspend_timer_;
 //]
     boost::fibers::scheduler::ready_queue_type      rqueue_{};
@@ -46,14 +46,14 @@ private:
 
 public:
 //[asio_rr_service_top
-    struct service : public boost::asio::io_service::service {
-        static boost::asio::io_service::id                  id;
+    struct service : public boost::asio::io_context::service {
+        static boost::asio::io_context::id                  id;
 
-        std::unique_ptr< boost::asio::io_service::work >    work_;
+        std::unique_ptr< boost::asio::io_context::work >    work_;
 
-        service( boost::asio::io_service & io_svc) :
-            boost::asio::io_service::service( io_svc),
-            work_{ new boost::asio::io_service::work( io_svc) } {
+        service( boost::asio::io_context & io_ctx) :
+            boost::asio::io_context::service( io_ctx),
+            work_{ new boost::asio::io_context::work( io_ctx) } {
         }
 
         virtual ~service() {}
@@ -68,28 +68,28 @@ public:
 //]
 
 //[asio_rr_ctor
-    round_robin( std::shared_ptr< boost::asio::io_service > const& io_svc) :
-        io_svc_( io_svc),
-        suspend_timer_( * io_svc_) {
+    round_robin( std::shared_ptr< boost::asio::io_context > const& io_ctx_) :
+        io_ctx_( io_ctx),
+        suspend_timer_( * io_ctx_) {
         // We use add_service() very deliberately. This will throw
-        // service_already_exists if you pass the same io_service instance to
+        // service_already_exists if you pass the same io_context instance to
         // more than one round_robin instance.
-        boost::asio::add_service( * io_svc_, new service( * io_svc_) );
-        io_svc_->post([this]() mutable {
+        boost::asio::add_service( * io_ctx_, new service( * io_ctx_) );
+        io_ctx_->post([this]() mutable {
 //]
 //[asio_rr_service_lambda
-                while ( ! io_svc_->stopped() ) {
+                while ( ! io_ctx_->stopped() ) {
                     if ( has_ready_fibers() ) {
                         // run all pending handlers in round_robin
-                        while ( io_svc_->poll() );
+                        while ( io_ctx_->poll() );
                         // block this fiber till all pending (ready) fibers are processed
                         // == round_robin::suspend_until() has been called
                         std::unique_lock< boost::fibers::mutex > lk( mtx_);
                         cnd_.wait( lk);
                     } else {
-                        // run one handler inside io_service
+                        // run one handler inside io_context
                         // if no handler available, block this thread
-                        if ( ! io_svc_->run_one() ) {
+                        if ( ! io_ctx_->run_one() ) {
                             break;
                         }
                     }
@@ -183,7 +183,7 @@ public:
 //]
 };
 
-boost::asio::io_service::id round_robin::service::id;
+boost::asio::io_context::id round_robin::service::id;
 
 }}}
 

--- a/examples/asio/round_robin.hpp
+++ b/examples/asio/round_robin.hpp
@@ -75,7 +75,7 @@ public:
         // service_already_exists if you pass the same io_context instance to
         // more than one round_robin instance.
         boost::asio::add_service( * io_ctx_, new service( * io_ctx_) );
-        io_ctx_->post([this]() mutable {
+        boost::asio::post( * io_ctx_, [this]() mutable {
 //]
 //[asio_rr_service_lambda
                 while ( ! io_ctx_->stopped() ) {


### PR DESCRIPTION
Resolves #244 

I currently don't have any build environment for fibre, so the changes are untested. Do you have a CI that can confirm that it works?

Essentially its just find/replace:
type: `io_service -> io_context`
variable name: `io_svc -> io_ctx`

I also replaced usage of `io_context::post` method to use the free `asio::post` function instead.

Regards, Martin