### PR TITLE
introduce waker and wait_queue abstractions. fixes #251, #259

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -57,6 +57,7 @@ lib boost_fiber
       condition_variable.cpp
       context.cpp
       fiber.cpp
+      waker.cpp
       future.cpp
       mutex.cpp
       properties.cpp

--- a/include/boost/fiber/condition_variable.hpp
+++ b/include/boost/fiber/condition_variable.hpp
@@ -24,6 +24,7 @@
 #include <boost/fiber/exceptions.hpp>
 #include <boost/fiber/mutex.hpp>
 #include <boost/fiber/operations.hpp>
+#include <boost/fiber/waker.hpp>
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_PREFIX
@@ -44,10 +45,8 @@ enum class cv_status {
 
 class BOOST_FIBERS_DECL condition_variable_any {
 private:
-    using wait_queue_t = context::wait_queue_t;
-
     detail::spinlock    wait_queue_splk_{};
-    wait_queue_t        wait_queue_{};
+    wait_queue          wait_queue_{};
 
 public:
     condition_variable_any() = default;
@@ -69,13 +68,9 @@ public:
         // atomically call lt.unlock() and block on *this
         // store this fiber in waiting-queue
         detail::spinlock_lock lk{ wait_queue_splk_ };
-        BOOST_ASSERT( ! active_ctx->wait_is_linked() );
-        active_ctx->wait_link( wait_queue_);
-        active_ctx->twstatus.store( static_cast< std::intptr_t >( 0), std::memory_order_release);
-        // unlock external lt
         lt.unlock();
-        // suspend this fiber
-        active_ctx->suspend( lk);
+        wait_queue_.suspend_and_wait( lk, active_ctx);
+
         // relock external again before returning
         try {
             lt.lock();
@@ -86,8 +81,6 @@ public:
         } catch (...) {
             std::terminate();
         }
-        // post-conditions
-        BOOST_ASSERT( ! active_ctx->wait_is_linked() );
     }
 
     template< typename LockType, typename Pred >
@@ -105,20 +98,10 @@ public:
         // atomically call lt.unlock() and block on *this
         // store this fiber in waiting-queue
         detail::spinlock_lock lk{ wait_queue_splk_ };
-        BOOST_ASSERT( ! active_ctx->wait_is_linked() );
-        active_ctx->wait_link( wait_queue_);
-        active_ctx->twstatus.store( reinterpret_cast< std::intptr_t >( this), std::memory_order_release);
         // unlock external lt
         lt.unlock();
-        // suspend this fiber
-        if ( ! active_ctx->wait_until( timeout_time, lk) ) {
+        if ( ! wait_queue_.suspend_and_wait_until( lk, active_ctx, timeout_time)) {
             status = cv_status::timeout;
-            // relock local lk
-            lk.lock();
-            // remove from waiting-queue
-            wait_queue_.remove( * active_ctx);
-            // unlock local lk
-            lk.unlock();
         }
         // relock external again before returning
         try {
@@ -130,8 +113,6 @@ public:
         } catch (...) {
             std::terminate();
         }
-        // post-conditions
-        BOOST_ASSERT( ! active_ctx->wait_is_linked() );
         return status;
     }
 

--- a/include/boost/fiber/mutex.hpp
+++ b/include/boost/fiber/mutex.hpp
@@ -14,6 +14,7 @@
 #include <boost/fiber/context.hpp>
 #include <boost/fiber/detail/config.hpp>
 #include <boost/fiber/detail/spinlock.hpp>
+#include <boost/fiber/waker.hpp>
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_PREFIX
@@ -33,10 +34,8 @@ class BOOST_FIBERS_DECL mutex {
 private:
     friend class condition_variable;
 
-    using wait_queue_type = context::wait_queue_t;
-
     detail::spinlock            wait_queue_splk_{};
-    wait_queue_type             wait_queue_{};
+    wait_queue                  wait_queue_{};
     context                 *   owner_{ nullptr };
 
 public:

--- a/include/boost/fiber/operations.hpp
+++ b/include/boost/fiber/operations.hpp
@@ -38,14 +38,12 @@ template< typename Clock, typename Duration >
 void sleep_until( std::chrono::time_point< Clock, Duration > const& sleep_time_) {
     std::chrono::steady_clock::time_point sleep_time = boost::fibers::detail::convert( sleep_time_);
     fibers::context * active_ctx = fibers::context::active();
-    active_ctx->twstatus.store( static_cast< std::intptr_t >( 0), std::memory_order_release);
     active_ctx->wait_until( sleep_time);
 }
 
 template< typename Rep, typename Period >
 void sleep_for( std::chrono::duration< Rep, Period > const& timeout_duration) {
     fibers::context * active_ctx = fibers::context::active();
-    active_ctx->twstatus.store( static_cast< std::intptr_t >( 0), std::memory_order_release);
     active_ctx->wait_until( std::chrono::steady_clock::now() + timeout_duration);
 }
 

--- a/include/boost/fiber/recursive_mutex.hpp
+++ b/include/boost/fiber/recursive_mutex.hpp
@@ -18,6 +18,7 @@
 #include <boost/fiber/context.hpp>
 #include <boost/fiber/detail/config.hpp>
 #include <boost/fiber/detail/spinlock.hpp>
+#include <boost/fiber/waker.hpp>
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_PREFIX
@@ -37,10 +38,8 @@ class BOOST_FIBERS_DECL recursive_mutex {
 private:
     friend class condition_variable;
 
-    using wait_queue_type = context::wait_queue_t;
-
     detail::spinlock            wait_queue_splk_{};
-    wait_queue_type             wait_queue_{};
+    wait_queue                  wait_queue_{};
     context                 *   owner_{ nullptr };
     std::size_t                 count_{ 0 };
 

--- a/include/boost/fiber/recursive_timed_mutex.hpp
+++ b/include/boost/fiber/recursive_timed_mutex.hpp
@@ -20,6 +20,7 @@
 #include <boost/fiber/detail/config.hpp>
 #include <boost/fiber/detail/convert.hpp>
 #include <boost/fiber/detail/spinlock.hpp>
+#include <boost/fiber/waker.hpp>
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_PREFIX
@@ -39,10 +40,8 @@ class BOOST_FIBERS_DECL recursive_timed_mutex {
 private:
     friend class condition_variable;
 
-    using wait_queue_type = context::wait_queue_t;
-
     detail::spinlock            wait_queue_splk_{};
-    wait_queue_type             wait_queue_{};
+    wait_queue                  wait_queue_{};
     context                 *   owner_{ nullptr };
     std::size_t                 count_{ 0 };
 

--- a/include/boost/fiber/scheduler.hpp
+++ b/include/boost/fiber/scheduler.hpp
@@ -130,9 +130,11 @@ public:
 
     bool wait_until( context *,
                      std::chrono::steady_clock::time_point const&) noexcept;
+
     bool wait_until( context *,
                      std::chrono::steady_clock::time_point const&,
-                     detail::spinlock_lock &) noexcept;
+                     detail::spinlock_lock &,
+                     waker &&) noexcept;
 
     void suspend() noexcept;
     void suspend( detail::spinlock_lock &) noexcept;

--- a/include/boost/fiber/timed_mutex.hpp
+++ b/include/boost/fiber/timed_mutex.hpp
@@ -16,6 +16,7 @@
 #include <boost/fiber/detail/config.hpp>
 #include <boost/fiber/detail/convert.hpp>
 #include <boost/fiber/detail/spinlock.hpp>
+#include <boost/fiber/waker.hpp>
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_PREFIX
@@ -35,10 +36,8 @@ class BOOST_FIBERS_DECL timed_mutex {
 private:
     friend class condition_variable;
 
-    using wait_queue_type = context::wait_queue_t;
-
     detail::spinlock            wait_queue_splk_{};
-    wait_queue_type             wait_queue_{};
+    wait_queue                  wait_queue_{};
     context                 *   owner_{ nullptr };
 
     bool try_lock_until_( std::chrono::steady_clock::time_point const& timeout_time) noexcept;

--- a/include/boost/fiber/unbuffered_channel.hpp
+++ b/include/boost/fiber/unbuffered_channel.hpp
@@ -25,6 +25,7 @@
 #endif
 #include <boost/fiber/detail/spinlock.hpp>
 #include <boost/fiber/exceptions.hpp>
+#include <boost/fiber/waker.hpp>
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_PREFIX
@@ -39,20 +40,18 @@ public:
     using value_type = typename std::remove_reference<T>::type;
 
 private:
-    using wait_queue_type = context::wait_queue_t;
-
     struct slot {
         value_type  value;
-        context *   ctx;
+        waker       w;
 
-        slot( value_type const& value_, context * ctx_) :
+        slot( value_type const& value_, waker && w) :
             value{ value_ },
-            ctx{ ctx_ } {
+            w{ std::move(w) } {
         }
 
-        slot( value_type && value_, context * ctx_) :
+        slot( value_type && value_, waker && w) :
             value{ std::move( value_) },
-            ctx{ ctx_ } {
+            w{ std::move(w) } {
         }
     };
 
@@ -61,9 +60,9 @@ private:
     // shared cacheline
     std::atomic_bool            closed_{ false };
     mutable detail::spinlock    splk_producers_{};
-    wait_queue_type             waiting_producers_{};
+    wait_queue                  waiting_producers_{};
     mutable detail::spinlock    splk_consumers_{};
-    wait_queue_type             waiting_consumers_{};
+    wait_queue                  waiting_consumers_{};
     char                        pad_[cacheline_length];
 
     bool is_empty_() {
@@ -110,83 +109,41 @@ public:
     }
 
     void close() noexcept {
-        context * active_ctx = context::active();
         // set flag
         if ( ! closed_.exchange( true, std::memory_order_acquire) ) {
             // notify current waiting  
             slot * s = slot_.load( std::memory_order_acquire);
             if ( nullptr != s) {
                 // notify context
-                active_ctx->schedule( s->ctx);
+                s->w.wake();
             }
-            // notify all waiting producers
             detail::spinlock_lock lk1{ splk_producers_ };
-            while ( ! waiting_producers_.empty() ) {
-                context * producer_ctx = & waiting_producers_.front();
-                waiting_producers_.pop_front();
-                auto expected = reinterpret_cast< std::intptr_t >( this);
-                if ( producer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
-                    // notify context
-                    active_ctx->schedule( producer_ctx);
-                } else if ( static_cast< std::intptr_t >( 0) == expected) {
-                    // no timed-wait op.
-                    // notify context
-                    active_ctx->schedule( producer_ctx);
-                }
-            }
-            // notify all waiting consumers
+            waiting_producers_.notify_all();
+
             detail::spinlock_lock lk2{ splk_consumers_ };
-            while ( ! waiting_consumers_.empty() ) {
-                context * consumer_ctx = & waiting_consumers_.front();
-                waiting_consumers_.pop_front();
-                auto expected = reinterpret_cast< std::intptr_t >( this);
-                if ( consumer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
-                    // notify context
-                    active_ctx->schedule( consumer_ctx);
-                } else if ( static_cast< std::intptr_t >( 0) == expected) {
-                    // no timed-wait op.
-                    // notify context
-                    active_ctx->schedule( consumer_ctx);
-                }
-            }
+            waiting_consumers_.notify_all();
         }
     }
 
     channel_op_status push( value_type const& value) {
         context * active_ctx = context::active();
-        slot s{ value, active_ctx };
+        slot s{ value, active_ctx->create_waker() };
         for (;;) {
             if ( BOOST_UNLIKELY( is_closed() ) ) {
                 return channel_op_status::closed;
             }
             if ( try_push_( & s) ) {
                 detail::spinlock_lock lk{ splk_consumers_ };
-                // notify one waiting consumer
-                while ( ! waiting_consumers_.empty() ) {
-                    context * consumer_ctx = & waiting_consumers_.front();
-                    waiting_consumers_.pop_front();
-                    auto expected = reinterpret_cast< std::intptr_t >( this);
-                    if ( consumer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
-                        // notify context
-                        active_ctx->schedule( consumer_ctx);
-                        break;
-                    }
-                    if ( static_cast< std::intptr_t >( 0) == expected) {
-                        // no timed-wait op.
-                        // notify context
-                        active_ctx->schedule( consumer_ctx);
-                        break;
-                    }
-                }
+                waiting_consumers_.notify_one();
                 // suspend till value has been consumed
                 active_ctx->suspend( lk);
                 // resumed
-                if ( nullptr == s.ctx) {
-                    // value has been consumed
-                    return channel_op_status::success;
+                if ( BOOST_UNLIKELY( is_closed() ) ) {
+                    // channel was closed before value was consumed
+                    return channel_op_status::closed;
                 }
-                // channel was closed before value was consumed
-                return channel_op_status::closed;
+                // value has been consumed
+                return channel_op_status::success;
             }
             detail::spinlock_lock lk{ splk_producers_ };
             if ( BOOST_UNLIKELY( is_closed() ) ) {
@@ -195,48 +152,31 @@ public:
             if ( is_empty_() ) {
                 continue;
             }
-            active_ctx->wait_link( waiting_producers_);
-            active_ctx->twstatus.store( static_cast< std::intptr_t >( 0), std::memory_order_release);
-            // suspend this producer
-            active_ctx->suspend( lk);
+
+            waiting_producers_.suspend_and_wait( lk, active_ctx);
             // resumed, slot mabye free
         }
     }
 
     channel_op_status push( value_type && value) {
         context * active_ctx = context::active();
-        slot s{ std::move( value), active_ctx };
+        slot s{ std::move( value), active_ctx->create_waker() };
         for (;;) {
             if ( BOOST_UNLIKELY( is_closed() ) ) {
                 return channel_op_status::closed;
             }
             if ( try_push_( & s) ) {
                 detail::spinlock_lock lk{ splk_consumers_ };
-                // notify one waiting consumer
-                while ( ! waiting_consumers_.empty() ) {
-                    context * consumer_ctx = & waiting_consumers_.front();
-                    waiting_consumers_.pop_front();
-                    auto expected = reinterpret_cast< std::intptr_t >( this);
-                    if ( consumer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
-                        // notify context
-                        active_ctx->schedule( consumer_ctx);
-                        break;
-                    } if ( static_cast< std::intptr_t >( 0) == expected) {
-                        // no timed-wait op.
-                        // notify context
-                        active_ctx->schedule( consumer_ctx);
-                        break;
-                    }
-                }
+                waiting_consumers_.notify_one();
                 // suspend till value has been consumed
                 active_ctx->suspend( lk);
                 // resumed
-                if ( nullptr == s.ctx) {
-                    // value has been consumed
-                    return channel_op_status::success;
+                if ( BOOST_UNLIKELY( is_closed() ) ) {
+                    // channel was closed before value was consumed
+                    return channel_op_status::closed;
                 }
-                // channel was closed before value was consumed
-                return channel_op_status::closed;
+                // value has been consumed
+                return channel_op_status::success;
             }
             detail::spinlock_lock lk{ splk_producers_ };
             if ( BOOST_UNLIKELY( is_closed() ) ) {
@@ -245,10 +185,7 @@ public:
             if ( is_empty_() ) {
                 continue;
             }
-            active_ctx->wait_link( waiting_producers_);
-            active_ctx->twstatus.store( static_cast< std::intptr_t >( 0), std::memory_order_release);
-            // suspend this producer
-            active_ctx->suspend( lk);
+            waiting_producers_.suspend_and_wait( lk, active_ctx);
             // resumed, slot mabye free
         }
     }
@@ -271,7 +208,7 @@ public:
     channel_op_status push_wait_until( value_type const& value,
                                        std::chrono::time_point< Clock, Duration > const& timeout_time_) {
         context * active_ctx = context::active();
-        slot s{ value, active_ctx };
+        slot s{ value, active_ctx->create_waker() };
         std::chrono::steady_clock::time_point timeout_time = detail::convert( timeout_time_);
         for (;;) {
             if ( BOOST_UNLIKELY( is_closed() ) ) {
@@ -279,26 +216,9 @@ public:
             }
             if ( try_push_( & s) ) {
                 detail::spinlock_lock lk{ splk_consumers_ };
-                // notify one waiting consumer
-                while ( ! waiting_consumers_.empty() ) {
-                    context * consumer_ctx = & waiting_consumers_.front();
-                    waiting_consumers_.pop_front();
-                    auto expected = reinterpret_cast< std::intptr_t >( this);
-                    if ( consumer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
-                        // notify context
-                        active_ctx->schedule( consumer_ctx);
-                        break;
-                    }
-                    if ( static_cast< std::intptr_t >( 0) == expected) {
-                        // no timed-wait op.
-                        // notify context
-                        active_ctx->schedule( consumer_ctx);
-                        break;
-                    }
-                }
+                waiting_consumers_.notify_one();
                 // suspend this producer
-                active_ctx->twstatus.store( reinterpret_cast< std::intptr_t >( this), std::memory_order_release);
-                if ( ! active_ctx->wait_until( timeout_time, lk) ) {
+                if ( ! active_ctx->wait_until(timeout_time, lk, waker(s.w))) {
                     // clear slot
                     slot * nil_slot = nullptr, * own_slot = & s;
                     slot_.compare_exchange_strong( own_slot, nil_slot, std::memory_order_acq_rel);
@@ -306,12 +226,12 @@ public:
                     return channel_op_status::timeout;
                 }
                 // resumed
-                if ( nullptr == s.ctx) {
-                    // value has been consumed
-                    return channel_op_status::success;
+                if ( BOOST_UNLIKELY( is_closed() ) ) {
+                    // channel was closed before value was consumed
+                    return channel_op_status::closed;
                 }
-                // channel was closed before value was consumed
-                return channel_op_status::closed;
+                // value has been consumed
+                return channel_op_status::success;
             }
             detail::spinlock_lock lk{ splk_producers_ };
             if ( BOOST_UNLIKELY( is_closed() ) ) {
@@ -320,14 +240,9 @@ public:
             if ( is_empty_() ) {
                 continue;
             }
-            active_ctx->wait_link( waiting_producers_);
-            active_ctx->twstatus.store( reinterpret_cast< std::intptr_t >( this), std::memory_order_release);
-            // suspend this producer
-            if ( ! active_ctx->wait_until( timeout_time, lk) ) {
-                // relock local lk
-                lk.lock();
-                // remove from waiting-queue
-                waiting_producers_.remove( * active_ctx);
+
+            if (! waiting_producers_.suspend_and_wait_until( lk, active_ctx, timeout_time))
+            {
                 return channel_op_status::timeout;
             }
             // resumed, slot maybe free
@@ -338,7 +253,7 @@ public:
     channel_op_status push_wait_until( value_type && value,
                                        std::chrono::time_point< Clock, Duration > const& timeout_time_) {
         context * active_ctx = context::active();
-        slot s{ std::move( value), active_ctx };
+        slot s{ std::move( value), active_ctx->create_waker() };
         std::chrono::steady_clock::time_point timeout_time = detail::convert( timeout_time_);
         for (;;) {
             if ( BOOST_UNLIKELY( is_closed() ) ) {
@@ -346,25 +261,9 @@ public:
             }
             if ( try_push_( & s) ) {
                 detail::spinlock_lock lk{ splk_consumers_ };
-                // notify one waiting consumer
-                while ( ! waiting_consumers_.empty() ) {
-                    context * consumer_ctx = & waiting_consumers_.front();
-                    waiting_consumers_.pop_front();
-                    auto expected = reinterpret_cast< std::intptr_t >( this);
-                    if ( consumer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
-                        // notify context
-                        active_ctx->schedule( consumer_ctx);
-                        break;
-                    } if ( static_cast< std::intptr_t >( 0) == expected) {
-                        // no timed-wait op.
-                        // notify context
-                        active_ctx->schedule( consumer_ctx);
-                        break;
-                    }
-                }
+                waiting_consumers_.notify_one();
                 // suspend this producer
-                active_ctx->twstatus.store( reinterpret_cast< std::intptr_t >( this), std::memory_order_release);
-                if ( ! active_ctx->wait_until( timeout_time, lk) ) {
+                if ( ! active_ctx->wait_until(timeout_time, lk, waker(s.w))) {
                     // clear slot
                     slot * nil_slot = nullptr, * own_slot = & s;
                     slot_.compare_exchange_strong( own_slot, nil_slot, std::memory_order_acq_rel);
@@ -372,12 +271,12 @@ public:
                     return channel_op_status::timeout;
                 }
                 // resumed
-                if ( nullptr == s.ctx) {
-                    // value has been consumed
-                    return channel_op_status::success;
+                if ( BOOST_UNLIKELY( is_closed() ) ) {
+                    // channel was closed before value was consumed
+                    return channel_op_status::closed;
                 }
-                // channel was closed before value was consumed
-                return channel_op_status::closed;
+                // value has been consumed
+                return channel_op_status::success;
             }
             detail::spinlock_lock lk{ splk_producers_ };
             if ( BOOST_UNLIKELY( is_closed() ) ) {
@@ -386,14 +285,8 @@ public:
             if ( is_empty_() ) {
                 continue;
             }
-            active_ctx->wait_link( waiting_producers_);
-            active_ctx->twstatus.store( reinterpret_cast< std::intptr_t >( this), std::memory_order_release);
-            // suspend this producer
-            if ( ! active_ctx->wait_until( timeout_time, lk) ) {
-                // relock local lk
-                lk.lock();
-                // remove from waiting-queue
-                waiting_producers_.remove( * active_ctx);
+            if (! waiting_producers_.suspend_and_wait_until( lk, active_ctx, timeout_time))
+            {
                 return channel_op_status::timeout;
             }
             // resumed, slot maybe free
@@ -407,32 +300,11 @@ public:
             if ( nullptr != ( s = try_pop_() ) ) {
                 {
                     detail::spinlock_lock lk{ splk_producers_ };
-                    // notify one waiting producer
-                    while ( ! waiting_producers_.empty() ) {
-                        context * producer_ctx = & waiting_producers_.front();
-                        waiting_producers_.pop_front();
-                        auto expected = reinterpret_cast< std::intptr_t >( this);
-                        if ( producer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
-                            lk.unlock();
-                            // notify context
-                            active_ctx->schedule( producer_ctx);
-                            break;
-                        } if ( static_cast< std::intptr_t >( 0) == expected) {
-                            lk.unlock();
-                            // no timed-wait op.
-                            // notify context
-                            active_ctx->schedule( producer_ctx);
-                            break;
-                        }
-                    }
+                    waiting_producers_.notify_one();
                 }
                 value = std::move( s->value);
                 // notify context
-#if defined(BOOST_NO_CXX14_STD_EXCHANGE)
-                active_ctx->schedule( detail::exchange( s->ctx, nullptr) );
-#else
-                active_ctx->schedule( std::exchange( s->ctx, nullptr) );
-#endif
+                s->w.wake();
                 return channel_op_status::success;
             }
             detail::spinlock_lock lk{ splk_consumers_ };
@@ -442,10 +314,7 @@ public:
             if ( ! is_empty_() ) {
                 continue;
             }
-            active_ctx->wait_link( waiting_consumers_);
-            active_ctx->twstatus.store( static_cast< std::intptr_t >( 0), std::memory_order_release);
-            // suspend this consumer
-            active_ctx->suspend( lk);
+            waiting_consumers_.suspend_and_wait( lk, active_ctx);
             // resumed, slot mabye set
         }
     }
@@ -457,33 +326,12 @@ public:
             if ( nullptr != ( s = try_pop_() ) ) {
                 {
                     detail::spinlock_lock lk{ splk_producers_ };
-                    // notify one waiting producer
-                    while ( ! waiting_producers_.empty() ) {
-                        context * producer_ctx = & waiting_producers_.front();
-                        waiting_producers_.pop_front();
-                        auto expected = reinterpret_cast< std::intptr_t >( this);
-                        if ( producer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
-                            lk.unlock();
-                            // notify context
-                            active_ctx->schedule( producer_ctx);
-                            break;
-                        } if ( static_cast< std::intptr_t >( 0) == expected) {
-                            lk.unlock();
-                            // no timed-wait op.
-                            // notify context
-                            active_ctx->schedule( producer_ctx);
-                            break;
-                        }
-                    }
+                    waiting_producers_.notify_one();
                 }
                 // consume value
                 value_type value = std::move( s->value);
                 // notify context
-#if defined(BOOST_NO_CXX14_STD_EXCHANGE)
-                active_ctx->schedule( detail::exchange( s->ctx, nullptr) );
-#else
-                active_ctx->schedule( std::exchange( s->ctx, nullptr) );
-#endif
+                s->w.wake();
                 return std::move( value);
             }
             detail::spinlock_lock lk{ splk_consumers_ };
@@ -495,10 +343,7 @@ public:
             if ( ! is_empty_() ) {
                 continue;
             }
-            active_ctx->wait_link( waiting_consumers_);
-            active_ctx->twstatus.store( static_cast< std::intptr_t >( 0), std::memory_order_release);
-            // suspend this consumer
-            active_ctx->suspend( lk);
+            waiting_consumers_.suspend_and_wait( lk, active_ctx);
             // resumed, slot mabye set
         }
     }
@@ -520,34 +365,12 @@ public:
             if ( nullptr != ( s = try_pop_() ) ) {
                 {
                     detail::spinlock_lock lk{ splk_producers_ };
-                    // notify one waiting producer
-                    while ( ! waiting_producers_.empty() ) {
-                        context * producer_ctx = & waiting_producers_.front();
-                        waiting_producers_.pop_front();
-                        auto expected = reinterpret_cast< std::intptr_t >( this);
-                        if ( producer_ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
-                            lk.unlock();
-                            // notify context
-                            active_ctx->schedule( producer_ctx);
-                            break;
-                        }
-                        if ( static_cast< std::intptr_t >( 0) == expected) {
-                            lk.unlock();
-                            // no timed-wait op.
-                            // notify context
-                            active_ctx->schedule( producer_ctx);
-                            break;
-                        }
-                    }
+                    waiting_producers_.notify_one();
                 }
                 // consume value
                 value = std::move( s->value);
                 // notify context
-#if defined(BOOST_NO_CXX14_STD_EXCHANGE)
-                active_ctx->schedule( detail::exchange( s->ctx, nullptr) );
-#else
-                active_ctx->schedule( std::exchange( s->ctx, nullptr) );
-#endif
+                s->w.wake();
                 return channel_op_status::success;
             }
             detail::spinlock_lock lk{ splk_consumers_ };
@@ -557,14 +380,7 @@ public:
             if ( ! is_empty_() ) {
                 continue;
             }
-            active_ctx->wait_link( waiting_consumers_);
-            active_ctx->twstatus.store( reinterpret_cast< std::intptr_t >( this), std::memory_order_release);
-            // suspend this consumer
-            if ( ! active_ctx->wait_until( timeout_time, lk) ) {
-                // relock local lk
-                lk.lock();
-                // remove from waiting-queue
-                waiting_consumers_.remove( * active_ctx);
+            if ( ! waiting_consumers_.suspend_and_wait_until( lk, active_ctx, timeout_time)) {
                 return channel_op_status::timeout;
             }
         }

--- a/include/boost/fiber/waker.hpp
+++ b/include/boost/fiber/waker.hpp
@@ -1,0 +1,88 @@
+#ifndef BOOST_FIBERS_WAKER_H
+#define BOOST_FIBERS_WAKER_H
+
+#include <cstddef>
+
+#include <boost/config.hpp>
+#include <boost/fiber/detail/config.hpp>
+#include <boost/fiber/detail/spinlock.hpp>
+#include <boost/intrusive/slist.hpp>
+
+namespace boost {
+namespace fibers {
+
+class context;
+
+namespace detail {
+
+typedef intrusive::slist_member_hook<> waker_queue_hook;
+
+} // detail
+
+
+class BOOST_FIBERS_DECL waker {
+public:
+    friend class context;
+
+    waker() = default;
+
+    waker(context * ctx, const size_t epoch)
+        : ctx_{ ctx }
+        , epoch_{ epoch }
+    {}
+
+    bool wake() const noexcept;
+
+private:
+    context *ctx_{};
+    size_t epoch_{};
+};
+
+
+class BOOST_FIBERS_DECL waker_with_hook : public waker {
+public:
+    explicit waker_with_hook(waker && w)
+        : waker{ std::move(w) }
+    {}
+
+    bool is_linked() const noexcept {
+        return waker_queue_hook_.is_linked();
+    }
+
+    friend bool
+    operator==( waker const& lhs, waker const& rhs) noexcept {
+        return & lhs == & rhs;
+    }
+
+public:
+    detail::waker_queue_hook waker_queue_hook_{};
+};
+
+namespace detail {
+    typedef intrusive::slist<
+            waker_with_hook,
+            intrusive::member_hook<
+                waker_with_hook, detail::waker_queue_hook, & waker_with_hook::waker_queue_hook_ >,
+            intrusive::constant_time_size< false >,
+            intrusive::cache_last< true >
+        >                                               waker_slist_t;
+}
+
+class BOOST_FIBERS_DECL wait_queue : public detail::waker_slist_t
+{
+    using base = detail::waker_slist_t;
+public:
+    using base::base;
+
+    void suspend_and_wait( detail::spinlock_lock &, context *);
+    bool suspend_and_wait_until( detail::spinlock_lock &,
+                                 context *,
+                                 std::chrono::steady_clock::time_point const&);
+    void notify_one();
+    void notify_all();
+};
+
+} // fibers
+} // boost
+
+#endif // BOOST_FIBERS_WAKER_H

--- a/src/condition_variable.cpp
+++ b/src/condition_variable.cpp
@@ -17,46 +17,14 @@ namespace fibers {
 
 void
 condition_variable_any::notify_one() noexcept {
-    context * active_ctx = context::active();
-    // get one context' from wait-queue
     detail::spinlock_lock lk{ wait_queue_splk_ };
-    while ( ! wait_queue_.empty() ) {
-        context * ctx = & wait_queue_.front();
-        wait_queue_.pop_front();
-        auto expected = reinterpret_cast< std::intptr_t >( this);
-        if ( ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
-            // notify context
-            active_ctx->schedule( ctx);
-            break;
-        }
-        if ( static_cast< std::intptr_t >( 0) == expected) {
-            // no timed-wait op.
-            // notify context
-            active_ctx->schedule( ctx);
-            break;
-        }
-    }
+    wait_queue_.notify_one();
 }
 
 void
 condition_variable_any::notify_all() noexcept {
-    context * active_ctx = context::active();
-    // get all context' from wait-queue
     detail::spinlock_lock lk{ wait_queue_splk_ };
-    // notify all context'
-    while ( ! wait_queue_.empty() ) {
-        context * ctx = & wait_queue_.front();
-        wait_queue_.pop_front();
-        auto expected = reinterpret_cast< std::intptr_t >( this);
-        if ( ctx->twstatus.compare_exchange_strong( expected, static_cast< std::intptr_t >( -1), std::memory_order_acq_rel) ) {
-            // notify context
-            active_ctx->schedule( ctx);
-        } else if ( static_cast< std::intptr_t >( 0) == expected) {
-            // no timed-wait op.
-            // notify context
-            active_ctx->schedule( ctx);
-        }
-    }
+    wait_queue_.notify_all();
 }
 
 }}

--- a/src/mutex.cpp
+++ b/src/mutex.cpp
@@ -12,6 +12,7 @@
 
 #include "boost/fiber/exceptions.hpp"
 #include "boost/fiber/scheduler.hpp"
+#include "boost/fiber/waker.hpp"
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_PREFIX
@@ -35,11 +36,8 @@ mutex::lock() {
             owner_ = active_ctx;
             return;
         }
-        BOOST_ASSERT( ! active_ctx->wait_is_linked() );
-        active_ctx->wait_link( wait_queue_);
-        // suspend this fiber
-        active_ctx->suspend( lk);
-        BOOST_ASSERT( ! active_ctx->wait_is_linked() );
+
+        wait_queue_.suspend_and_wait( lk, active_ctx);
     }
 }
 
@@ -71,11 +69,8 @@ mutex::unlock() {
                 "boost fiber: no  privilege to perform the operation" };
     }
     owner_ = nullptr;
-    if ( ! wait_queue_.empty() ) {
-        context * ctx = & wait_queue_.front();
-        wait_queue_.pop_front();
-        active_ctx->schedule( ctx);
-    }
+
+    wait_queue_.notify_one();
 }
 
 }}

--- a/src/waker.cpp
+++ b/src/waker.cpp
@@ -1,0 +1,62 @@
+
+#include "boost/fiber/waker.hpp"
+#include "boost/fiber/context.hpp"
+
+namespace boost {
+namespace fibers {
+
+bool waker::wake() const noexcept
+{
+    BOOST_ASSERT(epoch_ > 0);
+    BOOST_ASSERT(ctx_ != nullptr);
+
+    return ctx_->wake(epoch_);
+}
+
+void wait_queue::suspend_and_wait( detail::spinlock_lock & lk, context * active_ctx) {
+    waker_with_hook w{ active_ctx->create_waker() };
+    base::push_back(w);
+    // suspend this fiber
+    active_ctx->suspend( lk);
+    BOOST_ASSERT( ! w.is_linked() );
+}
+
+bool wait_queue::suspend_and_wait_until( detail::spinlock_lock & lk,
+                                context * active_ctx,
+                                std::chrono::steady_clock::time_point const& timeout_time) {
+    waker_with_hook w{ active_ctx->create_waker() };
+    base::push_back(w);
+    // suspend this fiber
+    if ( ! active_ctx->wait_until( timeout_time, lk, waker(w)) ) {
+        // relock local lk
+        lk.lock();
+        // remove from waiting-queue
+        if ( w.is_linked()) {
+            base::remove( w);
+        }
+        lk.unlock();
+        return false;
+    }
+    return true;
+}
+
+void wait_queue::notify_one() {
+    while ( ! base::empty() ) {
+        waker & w = base::front();
+        base::pop_front();
+        if ( w.wake()) {
+            break;
+        }
+    }
+}
+
+void wait_queue::notify_all() {
+    while ( ! base::empty() ) {
+        waker & w = base::front();
+        base::pop_front();
+        w.wake();
+    }
+}
+
+}
+}


### PR DESCRIPTION
introduce waker and wait_queue abstractions. fixes #251, #259

```
* remove context::wait_hook_ and context::twstatus in flavor to waker_epoch_ and waker class
* this avoids data races in case of wait_until() operations, when the context
  could be timeouted and rescheduled on the other OS thread. In this case could
  be data races with context::wait_hook_ and inconsistences context::twstatus
  states.
* using context::waker_epoch_ introduces mechanism when the old wakers become
  outdated and waker::wake() is just no op. This fixes data races explained in
  the previous point
* fibers waiting queue with timeouts and notification mechanisms are incapsulated into
  wait_queue class. This introduce simple abstraction level to be used in
  different synchronization primitives
* the same wait_queue is used in context::wait_queue_ to synchronize fiber::join() operations
```

I know there is a huge diff! 
But this PR could be good for simplification and improved stability (correctness) of boost::fiber library.
Let's discuss it!