### PR TITLE
cpu_relax:  exclude octeon+ from the MIPS list

### DIFF
--- a/include/boost/fiber/detail/cpu_relax.hpp
+++ b/include/boost/fiber/detail/cpu_relax.hpp
@@ -47,7 +47,7 @@ namespace detail {
 # else
 #  define cpu_relax() asm volatile ("nop" ::: "memory");
 # endif
-#elif BOOST_ARCH_MIPS && (__mips_isa_rev > 1)
+#elif BOOST_ARCH_MIPS && (__mips_isa_rev > 1) && !defined(_MIPS_ARCH_OCTEONP)
 # define cpu_relax() asm volatile ("pause" ::: "memory");
 #elif BOOST_ARCH_PPC
 // http://code.metager.de/source/xref/gnu/glibc/sysdeps/powerpc/sys/platform/ppc.h


### PR DESCRIPTION
The pause MIPS instruction was added in version 2.6 of the standard. Unfortunately,
octeon+ seems to be based on an older standard. Also unfortunately GCC doesn't
have a macro for minor ISA versions.