### PR TITLE
cpu_relax: fixup MIPS check for 64-bit

### DIFF
--- a/include/boost/fiber/detail/cpu_relax.hpp
+++ b/include/boost/fiber/detail/cpu_relax.hpp
@@ -47,7 +47,7 @@ namespace detail {
 # else
 #  define cpu_relax() asm volatile ("nop" ::: "memory");
 # endif
-#elif BOOST_ARCH_MIPS && (__mips_isa_rev > 1) && !defined(_MIPS_ARCH_OCTEONP)
+#elif BOOST_ARCH_MIPS && (((__mips_isa_rev > 1) && defined(__mips32)) || ((__mips_isa_rev > 2)  && defined(__mips64)))
 # define cpu_relax() asm volatile ("pause" ::: "memory");
 #elif BOOST_ARCH_PPC
 // http://code.metager.de/source/xref/gnu/glibc/sysdeps/powerpc/sys/platform/ppc.h


### PR DESCRIPTION
It turns out that this is also broken on mips64el. Further testing
reveals that

-mips32r2 -mtune=mips32r2 -mabi=32

compiles the PAUSE instruction just fine whereas

-mips64r2 -mtune=mips64r2 -mabi=64

does not. The PAUSE instruction was introduced in version 2.6 of the
MIPS ISA and GCC for some reason does not allow usage of it with MIPS64.
Modify the macro to fix the situation instead of just matching on
octeon, which is not quite correct.