### PR TITLE
Fix build with cmake and MinGW

### DIFF
--- a/src/numa/windows/pin_thread.cpp
+++ b/src/numa/windows/pin_thread.cpp
@@ -23,7 +23,12 @@ namespace numa {
 
 BOOST_FIBERS_DECL
 void pin_thread( std::uint32_t cpuid) {
+#ifdef __MINGW32__
+    // Workaround for bug in mingw-w64: https://sourceforge.net/p/mingw-w64/bugs/908
+    pin_thread( cpuid, reinterpret_cast<std::thread::native_handle_type>(::GetCurrentThread()) );
+#else
     pin_thread( cpuid, ::GetCurrentThread() );
+#endif
 }
 
 BOOST_FIBERS_DECL
@@ -37,7 +42,12 @@ void pin_thread( std::uint32_t cpuid, std::thread::native_handle_type h) {
     uint32_t id = cpuid % 64; 
     // set the bit mask of the logical CPU
     affinity.Mask = static_cast< KAFFINITY >( 1) << id;
+#ifdef __MINGW32__
+    // Workaround for bug in mingw-w64: https://sourceforge.net/p/mingw-w64/bugs/908
+    if ( BOOST_UNLIKELY( 0 == ::SetThreadGroupAffinity( reinterpret_cast<HANDLE>(h), & affinity, nullptr) ) ) {
+#else
     if ( BOOST_UNLIKELY( 0 == ::SetThreadGroupAffinity( h, & affinity, nullptr) ) ) {
+#endif
         throw std::system_error(
                 std::error_code( ::GetLastError(), std::system_category() ),
                 "::SetThreadiGroupAffinity() failed");


### PR DESCRIPTION
It fixes the following error during build using CMake and MinGW-w64:
(it allows to build whole Boost successfully)
```log
[ 27%] Building CXX object libs/fiber/CMakeFiles/boost_fiber_numa.dir/src/numa/windows/pin_thread.cpp.obj
C:\boost\libs\fiber\src\numa\windows\pin_thread.cpp: In function 'void boost::fibers::numa::pin_thread(uint32_t)':
C:\boost\libs\fiber\src\numa\windows\pin_thread.cpp:26:42: error: invalid conversion from 'HANDLE' {aka 'void*'} to 'std::thread::native_handle_type' {aka 'long long unsigned int'} [-fpermissive]
   26 |     pin_thread( cpuid, ::GetCurrentThread() );
      |                        ~~~~~~~~~~~~~~~~~~^~
      |                                          |
      |                                          HANDLE {aka void*}
In file included from C:\boost\libs\fiber\src\numa\windows\pin_thread.cpp:7:
C:/boost/libs/fiber/include/boost/fiber/numa/pin_thread.hpp:26:33: note:   initializing argument 2 of 'void boost::fibers::numa::pin_thread(uint32_t, std::thread::native_handle_type)'
   26 | void pin_thread( std::uint32_t, std::thread::native_handle_type);
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from C:/boost/libs/config/include/boost/config.hpp:39,
                 from C:/boost/libs/fiber/include/boost/fiber/numa/pin_thread.hpp:13,
                 from C:\boost\libs\fiber\src\numa\windows\pin_thread.cpp:7:
C:\boost\libs\fiber\src\numa\windows\pin_thread.cpp: In function 'void boost::fibers::numa::pin_thread(uint32_t, std::thread::native_handle_type)':
C:\boost\libs\fiber\src\numa\windows\pin_thread.cpp:40:57: error: invalid conversion from 'std::thread::native_handle_type' {aka 'long long unsigned int'} to 'HANDLE' {aka 'void*'} [-fpermissive]
   40 |     if ( BOOST_UNLIKELY( 0 == ::SetThreadGroupAffinity( h, & affinity, nullptr) ) ) {
      |                                                         ^
      |                                                         |
      |                                                         std::thread::native_handle_type {aka long long unsigned int}
C:/boost/libs/config/include/boost/config/compiler/gcc.hpp:96:44: note: in definition of macro 'BOOST_UNLIKELY'
   96 | #define BOOST_UNLIKELY(x) __builtin_expect(x, 0)
      |                                            ^
In file included from c:\mydevtools\mingw64\x86_64-w64-mingw32\include\winbase.h:30,
                 from c:\mydevtools\mingw64\x86_64-w64-mingw32\include\windows.h:70,
                 from C:\boost\libs\fiber\src\numa\windows\pin_thread.cpp:10:
c:\mydevtools\mingw64\x86_64-w64-mingw32\include\processtopologyapi.h:22:60: note:   initializing argument 1 of 'WINBOOL SetThreadGroupAffinity(HANDLE, const GROUP_AFFINITY*, PGROUP_AFFINITY)'
   22 |   WINBASEAPI WINBOOL WINAPI SetThreadGroupAffinity (HANDLE hThread, CONST GROUP_AFFINITY *GroupAffinity, PGROUP_AFFINITY PreviousGroupAffinity);
      |                                                     ~~~~~~~^~~~~~~
mingw32-make[2]: *** [libs\fiber\CMakeFiles\boost_fiber_numa.dir\build.make:76: libs/fiber/CMakeFiles/boost_fiber_numa.dir/src/numa/windows/pin_thread.cpp.obj] Error 1
```

Also see sibling issues, which are fixed by this merge request:
* [Build error with cmake and gcc (MinGW)](https://github.com/boostorg/fiber/issues/280)
* [error 1 while executing b2.exe](https://github.com/boostorg/fiber/issues/278)