### PR TITLE
fix buffered_channel of issue #256 - bug in spinlock_ttas

### DIFF
--- a/src/waker.cpp
+++ b/src/waker.cpp
@@ -31,7 +31,11 @@ wait_queue::suspend_and_wait_until( detail::spinlock_lock & lk,
     // suspend this fiber
     if ( ! active_ctx->wait_until( timeout_time, lk, waker(w)) ) {
         // relock local lk
-        lk.lock();
+        for(;;) {            
+            if(lk.try_lock())
+                break;
+            context::active()->yield();            
+        }
         // remove from waiting-queue
         if ( w.is_linked()) {
             slist_.remove( w);

--- a/src/waker.cpp
+++ b/src/waker.cpp
@@ -34,7 +34,7 @@ wait_queue::suspend_and_wait_until( detail::spinlock_lock & lk,
         for(;;) {            
             if(lk.try_lock())
                 break;
-            context::active()->yield();            
+            active_ctx->yield();            
         }
         // remove from waiting-queue
         if ( w.is_linked()) {


### PR DESCRIPTION
I also experienced this problem #256 and was able to reproduce the bug with @dixlorenz 's snippet. It seems the @dixlorenz suggestion of yielding inside spinlock_ttas would fix this but the problem is context header is only defined later. Since I don't have a deep understanding of this project I didn't felt comfortable of changing include header files order, also have no clue if that would be possible. 

I managed to fix the @dixlorenz snippet by yielding upfront in every buffered_channel call if spinlock_ttas try_lock fails. Of course this doesn't fix the spinlock_ttas problem but at least it seems to fix the buffered_channel hanging during the spinlock.