### PR TITLE
Allow setting fiber properties on construction

### DIFF
--- a/include/boost/fiber/fiber.hpp
+++ b/include/boost/fiber/fiber.hpp
@@ -105,7 +105,69 @@ public:
 #else
     fiber( launch policy, std::allocator_arg_t, StackAllocator && salloc, Fn && fn, Arg ... arg) :
 #endif
-        impl_{ make_worker_context( policy, std::forward< StackAllocator >( salloc), std::forward< Fn >( fn), std::forward< Arg >( arg) ... ) } {
+        fiber{ policy,
+               static_cast<fiber_properties*>(nullptr),
+               std::allocator_arg, std::forward< StackAllocator >( salloc),
+               std::forward< Fn >( fn), std::forward< Arg >( arg) ... } {
+    }
+
+    template< typename Fn,
+              typename ... Arg,
+              typename = detail::disable_overload< fiber, Fn >,
+              typename = detail::disable_overload< launch, Fn >,
+              typename = detail::disable_overload< std::allocator_arg_t, Fn >
+    >
+#if BOOST_COMP_GNUC < 50000000
+    explicit fiber( fiber_properties* properties, Fn && fn, Arg && ... arg) :
+#else
+    fiber( fiber_properties* properties, Fn && fn, Arg ... arg) :
+#endif
+        fiber{ launch::post,
+               properties,
+               std::allocator_arg, default_stack(),
+               std::forward< Fn >( fn), std::forward< Arg >( arg) ... } {
+    }
+
+    template< typename Fn,
+              typename ... Arg,
+              typename = detail::disable_overload< fiber, Fn >
+    >
+#if BOOST_COMP_GNUC < 50000000
+    fiber( launch policy, fiber_properties* properties, Fn && fn, Arg && ... arg) :
+#else
+    fiber( launch policy, fiber_properties* properties, Fn && fn, Arg ... arg) :
+#endif
+        fiber{ policy,
+               properties,
+               std::allocator_arg, default_stack(),
+               std::forward< Fn >( fn), std::forward< Arg >( arg) ... } {
+    }
+
+    template< typename StackAllocator,
+              typename Fn,
+              typename ... Arg
+    >
+#if BOOST_COMP_GNUC < 50000000
+    fiber( fiber_properties* properties, std::allocator_arg_t, StackAllocator && salloc, Fn && fn, Arg && ... arg) :
+#else
+    fiber( fiber_properties* properties, std::allocator_arg_t, StackAllocator && salloc, Fn && fn, Arg ... arg) :
+#endif
+        fiber{ launch::post,
+               properties,
+               std::allocator_arg, std::forward< StackAllocator >( salloc),
+               std::forward< Fn >( fn), std::forward< Arg >( arg) ... } {
+    }
+
+    template< typename StackAllocator,
+              typename Fn,
+              typename ... Arg
+    >
+#if BOOST_COMP_GNUC < 50000000
+    fiber( launch policy, fiber_properties* properties, std::allocator_arg_t, StackAllocator && salloc, Fn && fn, Arg && ... arg) :
+#else
+    fiber( launch policy, fiber_properties* properties, std::allocator_arg_t, StackAllocator && salloc, Fn && fn, Arg ... arg) :
+#endif
+        impl_{ make_worker_context_with_properties( policy, properties, std::forward< StackAllocator >( salloc), std::forward< Fn >( fn), std::forward< Arg >( arg) ... ) } {
         start_();
     }
 

--- a/include/boost/fiber/properties.hpp
+++ b/include/boost/fiber/properties.hpp
@@ -10,6 +10,7 @@
 #ifndef BOOST_FIBERS_PROPERTIES_HPP
 #define BOOST_FIBERS_PROPERTIES_HPP
 
+#include <boost/assert.hpp>
 #include <boost/fiber/detail/config.hpp>
 
 #ifdef BOOST_HAS_ABI_HEADERS
@@ -50,6 +51,9 @@ public:
 
     // fiber_properties, and by implication every subclass, must accept a back
     // pointer to its context.
+
+    // For fiber_properties passed to fiber constructors, nullptr must be
+    // used here.
     explicit fiber_properties( context * ctx) noexcept :
         ctx_{ ctx } {
     }
@@ -63,6 +67,14 @@ public:
     // must be able to call this
     void set_algorithm( algo::algorithm * algo) noexcept {
         algo_ = algo;
+    }
+
+    // not really intended for public use, but required to set properties
+    // on fiber/context construction.
+    void set_context( context* ctx ) noexcept {
+        BOOST_ASSERT( ctx_ == nullptr );
+        BOOST_ASSERT( ctx != nullptr );
+        ctx_ = ctx;
     }
 };
 


### PR DESCRIPTION
This PR allows fibers to be constructed with properties set. All existing APIs are kept and there is no ABI change.

It fixes issue https://github.com/boostorg/fiber/issues/283