### PR TITLE
futex: fix build on 32-bit architectures using 64-bit time_t

### DIFF
--- a/include/boost/fiber/detail/futex.hpp
+++ b/include/boost/fiber/detail/futex.hpp
@@ -12,6 +12,10 @@
 
 #include <boost/fiber/detail/config.hpp>
 
+#ifndef SYS_futex
+#define SYS_futex SYS_futex_time64
+#endif
+
 #if BOOST_OS_LINUX
 extern "C" {
 #include <linux/futex.h>


### PR DESCRIPTION
Fix the following build failure on 32-bit architectures using 64-bit
time_t (e.g. riscv32):
| ./boost/fiber/detail/futex.hpp:31:23: error: use of undeclared identifier 'SYS_futex'
|     return ::syscall( SYS_futex, addr, op, x, nullptr, nullptr, 0);
|                       ^
| 1 error generated.

Signed-off-by: Khem Raj <raj.khem@gmail.com>