### PR TITLE
Add missing const on comparison operators

### DIFF
--- a/src/numa/linux/topology.cpp
+++ b/src/numa/linux/topology.cpp
@@ -68,11 +68,11 @@ public:
         }
     }
 
-    bool operator==( directory_iterator const& other) {
+    bool operator==( directory_iterator const& other) const {
         return i_ == other.i_;
     }
 
-    bool operator!=( directory_iterator const& other) {
+    bool operator!=( directory_iterator const& other) const {
         return i_ != other.i_;
     }
 


### PR DESCRIPTION
This is detected as an error in C++20 (spaceship) in clang 14, since the operators become ambiguous against reversed candidates.