### PR TITLE
fix std::result_of for cpp20

### DIFF
--- a/include/boost/fiber/future/async.hpp
+++ b/include/boost/fiber/future/async.hpp
@@ -21,7 +21,7 @@
 namespace boost {
 namespace fibers {
 
-#if defined(BOOST_MSVC) && (_MSC_VER >= 1911 && _MSVC_LANG >= 201703)
+#if (defined(BOOST_MSVC) && (_MSC_VER >= 1911 && _MSVC_LANG >= 201703)) || __cplusplus >= 202002L
 template <typename>
 struct result_of;
 template <typename F, typename... Args>


### PR DESCRIPTION
it fixes build with C++20, because C++20 removed std::result_of.