### PR TITLE
Unbreak fiber for macOS PPC

### DIFF
--- a/include/boost/fiber/detail/cpu_relax.hpp
+++ b/include/boost/fiber/detail/cpu_relax.hpp
@@ -59,7 +59,11 @@ namespace detail {
 //               processors
 // extended mnemonics (available with POWER7)
 // yield   ==   or 27, 27, 27
+# if defined(__POWERPC__) // Darwin PPC
+# define cpu_relax() asm volatile ("or r27,r27,r27" ::: "memory");
+# else
 # define cpu_relax() asm volatile ("or 27,27,27" ::: "memory");
+# endif
 #elif BOOST_ARCH_X86
 # if BOOST_COMP_MSVC || BOOST_COMP_MSVC_EMULATED
 #  define cpu_relax() YieldProcessor();


### PR DESCRIPTION
@olk Remember we were wondering why `context` was fixed but `fiber` failed? I preprocessed sources and found the cause. Of course this could not possibly work.