### PR TITLE
avoid deprecated std::aligned_storage

### DIFF
--- a/include/boost/fiber/future/detail/shared_state.hpp
+++ b/include/boost/fiber/future/detail/shared_state.hpp
@@ -157,7 +157,7 @@ public:
 template< typename R >
 class shared_state : public shared_state_base {
 private:
-    typename std::aligned_storage< sizeof( R), alignof( R) >::type  storage_{};
+    alignas(alignof( R)) unsigned char storage_[sizeof( R)]{};
 
     void set_value_( R const& value, std::unique_lock< mutex > & lk) {
         BOOST_ASSERT( lk.owns_lock() );


### PR DESCRIPTION
this is in response to the deprecation warning noted in the mailing list.

I think this patch will get rid of the warning, and also give smaller objects on some compilers. 
see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61458 for details of std::aligned_storage size.

"
[build] /usr/include/boost/fiber/future/detail/shared_state.hpp:160:19:
warning: 'aligned_storage<4, 4>' is deprecated [-Wdeprecated-declarations]
[build]   160 |     typename std::aligned_storage< sizeof( R), alignof(
R) >::type  storage_{};
[build]       |                   ^
[build] /usr/include/boost/fiber/future/promise.hpp:28:22: note: in
instantiation of template class
'boost::fibers::detail::shared_state<int>' requested here
[build]    28 |     typedef typename shared_state< R >::ptr_type   ptr_type;
"