### PR TITLE
Unbreak fiber for ELF PowerPC building with Clang

### DIFF
--- a/include/boost/fiber/detail/cpu_relax.hpp
+++ b/include/boost/fiber/detail/cpu_relax.hpp
@@ -59,7 +59,7 @@ namespace detail {
 //               processors
 // extended mnemonics (available with POWER7)
 // yield   ==   or 27, 27, 27
-# if defined(__POWERPC__) // Darwin PPC
+# if defined(__APPLE__) // Darwin PPC
 # define cpu_relax() asm volatile ("or r27,r27,r27" ::: "memory");
 # else
 # define cpu_relax() asm volatile ("or 27,27,27" ::: "memory");


### PR DESCRIPTION
Clang also defines the uppercase ```__POWERPC__``` symbol so the commit
2bd8eb02f81ab8297aa89b8cb29b0f3867b9fafe breaks the build on ELF
PowerPC systems. Since we know this is already a PowerPC system
with ```BOOST_ARCH_PPC``` then check for the vendor ```__APPLE__``` instead.