### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,31 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/fiber
+    : common-requirements
+        <source>/boost/algorithm//boost_algorithm
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/context//boost_context
+        <source>/boost/core//boost_core
+        <source>/boost/filesystem//boost_filesystem
+        <source>/boost/format//boost_format
+        <source>/boost/intrusive//boost_intrusive
+        <source>/boost/predef//boost_predef
+        <source>/boost/smart_ptr//boost_smart_ptr
+        <include>include
+    ;
+
+explicit
+    [ alias boost_fiber : build//boost_fiber ]
+    [ alias boost_fiber_numa : build//boost_fiber_numa ]
+    [ alias all : boost_fiber examples examples/numa performance/fiber performance/fiber/numa test ]
+    ;
+
+call-if : boost-library fiber
+    : install boost_fiber boost_fiber_numa
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/fiber
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -7,16 +7,16 @@ import project ;
 
 project /boost/fiber
     : common-requirements
-        <source>/boost/algorithm//boost_algorithm
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/context//boost_context
-        <source>/boost/core//boost_core
-        <source>/boost/filesystem//boost_filesystem
-        <source>/boost/format//boost_format
-        <source>/boost/intrusive//boost_intrusive
-        <source>/boost/predef//boost_predef
-        <source>/boost/smart_ptr//boost_smart_ptr
+        <library>/boost/algorithm//boost_algorithm
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/context//boost_context
+        <library>/boost/core//boost_core
+        <library>/boost/filesystem//boost_filesystem
+        <library>/boost/format//boost_format
+        <library>/boost/intrusive//boost_intrusive
+        <library>/boost/predef//boost_predef
+        <library>/boost/smart_ptr//boost_smart_ptr
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/fiber

--- a/build.jam
+++ b/build.jam
@@ -6,13 +6,10 @@
 require-b2 5.2 ;
 
 constant boost_dependencies :
-    /boost/algorithm//boost_algorithm
     /boost/assert//boost_assert
     /boost/config//boost_config
     /boost/context//boost_context
     /boost/core//boost_core
-    /boost/filesystem//boost_filesystem
-    /boost/format//boost_format
     /boost/intrusive//boost_intrusive
     /boost/predef//boost_predef
     /boost/smart_ptr//boost_smart_ptr ;

--- a/build.jam
+++ b/build.jam
@@ -5,18 +5,20 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/algorithm//boost_algorithm
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/context//boost_context
+    /boost/core//boost_core
+    /boost/filesystem//boost_filesystem
+    /boost/format//boost_format
+    /boost/intrusive//boost_intrusive
+    /boost/predef//boost_predef
+    /boost/smart_ptr//boost_smart_ptr ;
+
 project /boost/fiber
     : common-requirements
-        <library>/boost/algorithm//boost_algorithm
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/context//boost_context
-        <library>/boost/core//boost_core
-        <library>/boost/filesystem//boost_filesystem
-        <library>/boost/format//boost_format
-        <library>/boost/intrusive//boost_intrusive
-        <library>/boost/predef//boost_predef
-        <library>/boost/smart_ptr//boost_smart_ptr
         <include>include
     ;
 
@@ -29,3 +31,4 @@ explicit
 call-if : boost-library fiber
     : install boost_fiber boost_fiber_numa
     ;
+

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -9,12 +9,12 @@ import feature ;
 import modules ;
 import testing ;
 import toolset ;
-import ../../config/checks/config : requires ;
+import config : requires ;
 
 feature.feature numa : on : optional propagated composite ;
 feature.compose <numa>on : <define>BOOST_USE_NUMA ;
 
-project boost/fiber
+project
     : requirements
       <library>/boost/context//boost_context
       <library>/boost/filesystem//boost_filesystem
@@ -65,7 +65,7 @@ lib boost_fiber
       recursive_timed_mutex.cpp
       timed_mutex.cpp
       scheduler.cpp
-    : <link>shared:<library>../../context/build//boost_context
+    : <link>shared:<library>/boost/context//boost_context
     [ requires cxx11_auto_declarations
                cxx11_constexpr
                cxx11_defaulted_functions
@@ -145,6 +145,3 @@ lib boost_fiber_numa
                cxx11_thread_local
                cxx11_variadic_templates ]
     ;
-
-
-boost-install boost_fiber boost_fiber_numa ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -31,6 +31,7 @@ project
       <link>shared:<define>BOOST_FIBERS_DYN_LINK=1
       <optimization>speed:<define>BOOST_DISABLE_ASSERTS
       <variant>release:<define>BOOST_DISABLE_ASSERTS
+      <define>BOOST_FIBERS_NO_LIB=1
     : source-location ../src
     ;
 

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -9,6 +9,7 @@ import feature ;
 import modules ;
 import testing ;
 import toolset ;
+import-search /boost/config/checks ;
 import config : requires ;
 
 feature.feature numa : on : optional propagated composite ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -16,6 +16,7 @@ feature.feature numa : on : optional propagated composite ;
 feature.compose <numa>on : <define>BOOST_USE_NUMA ;
 
 project
+    : common-requirements <library>$(boost_dependencies)
     : requirements
       <library>/boost/context//boost_context
       <library>/boost/filesystem//boost_filesystem

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -11,13 +11,22 @@ import testing ;
 import toolset ;
 import-search /boost/config/checks ;
 import config : requires ;
+import-search /boost/context ;
+import boost-context-features ;
 
 feature.feature numa : on : optional propagated composite ;
 feature.compose <numa>on : <define>BOOST_USE_NUMA ;
 
+constant boost_dependencies_private :
+    /boost/algorithm//boost_algorithm
+    /boost/filesystem//boost_filesystem
+    /boost/format//boost_format
+    ;
+
 project
     : common-requirements <library>$(boost_dependencies)
     : requirements
+      <library>$(boost_dependencies_private)
       <library>/boost/context//boost_context
       <library>/boost/filesystem//boost_filesystem
       <target-os>solaris:<linkflags>"-llgrp"

--- a/examples/Jamfile.v2
+++ b/examples/Jamfile.v2
@@ -14,7 +14,7 @@ import modules ;
 import os ;
 import toolset ;
 
-project boost/fiber/example
+project
     : requirements
       <library>../build//boost_fiber
       <library>/boost/context//boost_context
@@ -42,12 +42,12 @@ exe range_for : range_for.cpp ;
 exe priority : priority.cpp ;
 exe segmented_stack : segmented_stack.cpp ;
 exe simple : simple.cpp ;
-exe wait_stuff : wait_stuff.cpp ;
+exe wait_stuff : wait_stuff.cpp /boost/variant//boost_variant ;
 exe work_sharing : work_sharing.cpp ;
 exe work_stealing : work_stealing.cpp ;
 
-exe asio/autoecho : asio/autoecho.cpp ;
-exe asio/exchange : asio/exchange.cpp ;
-exe asio/ps/publisher : asio/ps/publisher.cpp ;
-exe asio/ps/server : asio/ps/server.cpp ;
-exe asio/ps/subscriber : asio/ps/subscriber.cpp ;
+exe asio/autoecho : asio/autoecho.cpp /boost/asio//boost_asio ;
+exe asio/exchange : asio/exchange.cpp /boost/asio//boost_asio ;
+exe asio/ps/publisher : asio/ps/publisher.cpp /boost/asio//boost_asio ;
+exe asio/ps/server : asio/ps/server.cpp /boost/asio//boost_asio ;
+exe asio/ps/subscriber : asio/ps/subscriber.cpp /boost/asio//boost_asio ;

--- a/examples/numa/Jamfile.v2
+++ b/examples/numa/Jamfile.v2
@@ -14,7 +14,7 @@ import modules ;
 import os ;
 import toolset ;
 
-project boost/fiber/example/numa
+project
     : requirements
       <library>../../build//boost_fiber
       <library>../../build//boost_fiber_numa

--- a/performance/fiber/Jamfile.v2
+++ b/performance/fiber/Jamfile.v2
@@ -13,7 +13,7 @@ import modules ;
 import os ;
 import toolset ;
 
-project boost/fiber/performance/fiber
+project
     : requirements
       <library>/boost/fiber//boost_fiber
       <library>/boost/fiber//boost_fiber_numa

--- a/performance/fiber/numa/Jamfile.v2
+++ b/performance/fiber/numa/Jamfile.v2
@@ -13,7 +13,7 @@ import modules ;
 import os ;
 import toolset ;
 
-project boost/fiber/performance/fiber/numa
+project
     : requirements
       <library>/boost/fiber//boost_fiber
       <target-os>solaris:<linkflags>"-llgrp"

--- a/performance/thread/Jamfile.v2
+++ b/performance/thread/Jamfile.v2
@@ -13,7 +13,7 @@ import modules ;
 import os ;
 import toolset ;
 
-project boost/fiber/performance/thread
+project
     : requirements
       <link>static
       <threading>multi

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -13,9 +13,10 @@ import os ;
 import path ;
 import testing ;
 import toolset ;
+import-search /boost/config/checks ;
 import config : requires ;
 
-project 
+project
     : requirements
       <library>/boost/test//boost_unit_test_framework
       <library>/boost/context//boost_context

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -13,11 +13,11 @@ import os ;
 import path ;
 import testing ;
 import toolset ;
-import ../../config/checks/config : requires ;
+import config : requires ;
 
-project boost/fiber/test
+project 
     : requirements
-      <library>../../test/build//boost_unit_test_framework
+      <library>/boost/test//boost_unit_test_framework
       <library>/boost/context//boost_context
       <library>/boost/fiber//boost_fiber
       <library>/boost/thread//boost_thread


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.