### PR TITLE
Implement std::hash for boost::fibers::context::id

### DIFF
--- a/include/boost/fiber/context.hpp
+++ b/include/boost/fiber/context.hpp
@@ -174,6 +174,7 @@ private:
 public:
     class id {
     private:
+        friend std::hash<id>;
         context  *   impl_{ nullptr };
 
     public:
@@ -519,6 +520,17 @@ static intrusive_ptr< context > make_worker_context( launch policy,
 
 
 }}
+
+// std::hash specialization
+namespace std {
+
+template <>
+struct hash< ::boost::fibers::context::id > {
+    std::size_t
+    operator() ( ::boost::fibers::context::id const& id ) const noexcept;
+};
+
+}
 
 #ifdef _MSC_VER
 # pragma warning(pop)

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -434,6 +434,16 @@ context::attach( context * ctx) noexcept {
 
 }}
 
+namespace std {
+
+std::size_t
+hash< ::boost::fibers::context::id >::operator() ( ::boost::fibers::context::id const& id ) const noexcept {
+    return reinterpret_cast<std::size_t>(id.impl_);
+}
+
+}
+
+
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX
 #endif


### PR DESCRIPTION
Trick from Boost.Stacktrace https://github.com/boostorg/stacktrace/blob/0a1f8ac9a0caf250753411e82c645f750ba99317/include/boost/stacktrace/frame.hpp#L34

Closes #321 