### PR TITLE
Enable futex support in macOS 14.4+ through os_sync_wait_on_address

### DIFF
--- a/include/boost/fiber/detail/config.hpp
+++ b/include/boost/fiber/detail/config.hpp
@@ -10,8 +10,14 @@
 #include <cstddef>
 
 #include <boost/config.hpp>
-#include <boost/predef.h> 
+#include <boost/predef.h>
 #include <boost/detail/workaround.hpp>
+
+#if BOOST_OS_MACOS
+#include <Availability.h>
+#define BOOST_OS_SYNC_WAIT_ON_ADDRESS_AVAILABLE \
+    __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_14_4
+#endif
 
 #ifdef BOOST_FIBERS_DECL
 # undef BOOST_FIBERS_DECL
@@ -38,7 +44,8 @@
 # include <boost/config/auto_link.hpp>
 #endif
 
-#if BOOST_OS_LINUX || BOOST_OS_BSD_OPEN || BOOST_OS_WINDOWS
+#if BOOST_OS_LINUX || BOOST_OS_BSD_OPEN || BOOST_OS_WINDOWS || (BOOST_OS_MACOS && \
+    BOOST_OS_SYNC_WAIT_ON_ADDRESS_AVAILABLE)
 # define BOOST_FIBERS_HAS_FUTEX
 #endif
 


### PR DESCRIPTION
Hi! Starting with version 14.4, macOS SDK exposes a header that allows to operate with futexes: https://developer.apple.com/documentation/os/os_sync_wait_on_address.

I made a quick change, and it seems to work in my application: with the content of this PR, by defining `BOOST_FIBERS_SPINLOCK_TTAS_FUTEX` and an appropriate `CMAKE_OSX_DEPLOYMENT_TARGET`, I am able to use futex-based synchronisation primitives.

On versions prior to 14.4, the code should in principle default to its usual behaviour (pure spinlocks), so this should be a pretty self-contained change. Tests run with `b2 cflags=-mmacosx-version-min=14.4 cxxflags=-mmacosx-version-min=14.4` pass, however, I am willing to provide something else for due process, if you have something on your mind.