### PR TITLE
WIN32: fix comparison of different sizes into compute_cpu_set()

### DIFF
--- a/src/numa/windows/topology.cpp
+++ b/src/numa/windows/topology.cpp
@@ -90,7 +90,7 @@ public:
 
 std::set< std::uint32_t > compute_cpu_set( WORD group_id, KAFFINITY mask) {
 	std::set< std::uint32_t > cpus;
-	for ( int i = 0; i < sizeof( mask) * 8; ++i) {
+	for ( size_t i = 0; i < sizeof( mask) * 8; ++i) {
   		if ( mask & ( static_cast< KAFFINITY >( 1) << i) ) {
    			cpus.insert( static_cast< std::uint32_t >( 64 * group_id + i) );
   		}


### PR DESCRIPTION
Compiling with MinGW for x86_64/Aarch64 prints this warning:
```
libs/fiber/src/numa/windows/topology.cpp: In function ‘std::set<unsigned int> {anonymous}::compute_cpu_set(WORD, KAFFINITY)’:
libs/fiber/src/numa/windows/topology.cpp:93:28: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long long unsigned int’ [-Wsign-compare]
   93 |         for ( int i = 0; i < sizeof( mask) * 8; ++i) {
      |                          ~~^~~~~~~~~~~~~~~~~~~
```
This is correct because `sizeof()` returns `size_t`, but hopefully it can be fixed with a tiny change, by simply replacing `int` with `size_t`.
This is not dangerous, however it's still useful for removing this annoying warning when compiling, if possible.