### PR TITLE
fix CUDA header for runtime api

### DIFF
--- a/examples/cuda/multiple_streams.cu
+++ b/examples/cuda/multiple_streams.cu
@@ -12,7 +12,7 @@
 #include <random>
 #include <tuple>
 
-#include <cuda.h>
+#include <cuda_runtime_api.h>
 
 #include <boost/assert.hpp>
 #include <boost/bind.hpp>

--- a/examples/cuda/single_stream.cu
+++ b/examples/cuda/single_stream.cu
@@ -11,7 +11,7 @@
 #include <random>
 #include <tuple>
 
-#include <cuda.h>
+#include <cuda_runtime_api.h>
 
 #include <boost/assert.hpp>
 #include <boost/bind.hpp>

--- a/include/boost/fiber/cuda/waitfor.hpp
+++ b/include/boost/fiber/cuda/waitfor.hpp
@@ -17,7 +17,7 @@
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
 
-#include <cuda.h>
+#include <cuda_runtime_api.h>
 
 #include <boost/fiber/detail/config.hpp>
 #include <boost/fiber/detail/is_all_same.hpp>


### PR DESCRIPTION
The CUDA types (`cudaStream_t`, `cudaError_t`)  and functions `cudaStreamAddCallback` used are part of CUDA runtime API but the included header `cuda.h` is for CUDA driver API.

This gives a compilation error in client code compiled with host compiler unless `cuda_runtime_api.h` (CUDA runtime API  header) is included before `boost/fiber/`
The examples in this repo compile fine, but they are compiled with `nvcc` which takes care of CUDA includes anyway
