### PR TITLE
Relax restrictions on capacity of buffered_channel

### DIFF
--- a/doc/buffered_channel.qbk
+++ b/doc/buffered_channel.qbk
@@ -123,12 +123,12 @@ Class `buffered_channel` supports range-for syntax:
         explicit buffered_channel( std::size_t capacity);
 
 [variablelist
-[[Preconditions:] [`2<=capacity && 0==(capacity & (capacity-1))`]]
+[[Preconditions:] [`2<=capacity`]]
 [[Effects:] [The constructor constructs an object of class `buffered_channel`
 with an internal buffer of size `capacity`.]]
 [[Throws:] [`fiber_error`]]
 [[Error Conditions:] [
-[*invalid_argument]: if `0==capacity || 0!=(capacity & (capacity-1))`.]]
+[*invalid_argument]: if `capacity<2`.]]
 [[Notes:] [A `push()`, `push_wait_for()` or `push_wait_until()` will not block
 until the number of values in the channel becomes equal to `capacity`.
 The channel can hold only `capacity - 1` elements, otherwise it is

--- a/include/boost/fiber/buffered_channel.hpp
+++ b/include/boost/fiber/buffered_channel.hpp
@@ -64,7 +64,7 @@ private:
 public:
     explicit buffered_channel( std::size_t capacity) :
             capacity_{ capacity } {
-        if ( BOOST_UNLIKELY( 2 > capacity_ || 0 != ( capacity_ & (capacity_ - 1) ) ) ) { 
+        if ( BOOST_UNLIKELY( capacity_ < 2 ) ) { 
             throw fiber_error{ std::make_error_code( std::errc::invalid_argument),
                                "boost fiber: buffer capacity is invalid" };
         }

--- a/test/test_buffered_channel_dispatch.cpp
+++ b/test/test_buffered_channel_dispatch.cpp
@@ -11,6 +11,7 @@
 
 #include <boost/assert.hpp>
 #include <boost/test/unit_test.hpp>
+#include <boost/test/parameterized_test.hpp>
 
 #include <boost/fiber/all.hpp>
 
@@ -55,83 +56,89 @@ void test_zero_wm() {
     BOOST_CHECK( thrown);
 }
 
-void test_push() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_push(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( 1) );
 }
 
-void test_push_closed() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_push_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     c.close();
     BOOST_CHECK( boost::fibers::channel_op_status::closed == c.push( 1) );
 }
 
-void test_try_push() {
-    boost::fibers::buffered_channel< int > c( 2);
+void test_try_push(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( 1) );
 }
 
-void test_try_push_closed() {
-    boost::fibers::buffered_channel< int > c( 2);
+void test_try_push_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.try_push( 1) );
     c.close();
     BOOST_CHECK( boost::fibers::channel_op_status::closed == c.try_push( 2) );
 }
 
-void test_try_push_full() {
-    boost::fibers::buffered_channel< int > c( 2);
-    BOOST_CHECK( boost::fibers::channel_op_status::success == c.try_push( 1) );
+void test_try_push_full(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
+    for (int i = 1; i != static_cast<int>( channel_size); ++i) {
+        BOOST_CHECK( boost::fibers::channel_op_status::success == c.try_push( i) );
+    }
     BOOST_CHECK( boost::fibers::channel_op_status::full == c.try_push( 1) );
 }
 
-void test_push_wait_for() {
-    boost::fibers::buffered_channel< int > c( 2);
+void test_push_wait_for(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push_wait_for( 1, std::chrono::seconds( 1) ) );
 }
 
-void test_push_wait_for_closed() {
-    boost::fibers::buffered_channel< int > c( 2);
+void test_push_wait_for_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     c.close();
     BOOST_CHECK( boost::fibers::channel_op_status::closed == c.push_wait_for( 1, std::chrono::seconds( 1) ) );
 }
 
-void test_push_wait_for_timeout() {
-    boost::fibers::buffered_channel< int > c( 2);
-    BOOST_CHECK( boost::fibers::channel_op_status::success == c.push_wait_for( 1, std::chrono::seconds( 1) ) );
+void test_push_wait_for_timeout(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
+    for (int i = 1; i != static_cast<int>( channel_size); ++i) {
+        BOOST_CHECK( boost::fibers::channel_op_status::success == c.push_wait_for( i, std::chrono::seconds( 1) ) );
+    }
     BOOST_CHECK( boost::fibers::channel_op_status::timeout == c.push_wait_for( 1, std::chrono::seconds( 1) ) );
 }
 
-void test_push_wait_until() {
-    boost::fibers::buffered_channel< int > c( 2);
+void test_push_wait_until(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push_wait_until( 1,
                     std::chrono::system_clock::now() + std::chrono::seconds( 1) ) );
 }
 
-void test_push_wait_until_closed() {
-    boost::fibers::buffered_channel< int > c( 2);
+void test_push_wait_until_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     c.close();
     BOOST_CHECK( boost::fibers::channel_op_status::closed == c.push_wait_until( 1,
                     std::chrono::system_clock::now() + std::chrono::seconds( 1) ) );
 }
 
-void test_push_wait_until_timeout() {
-    boost::fibers::buffered_channel< int > c( 2);
-    BOOST_CHECK( boost::fibers::channel_op_status::success == c.push_wait_until( 1,
+void test_push_wait_until_timeout(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
+    for (int i = 1; i != static_cast<int>( channel_size); ++i) {
+        BOOST_CHECK( boost::fibers::channel_op_status::success == c.push_wait_until( i,
                     std::chrono::system_clock::now() + std::chrono::seconds( 1) ) );
+    }
     BOOST_CHECK( boost::fibers::channel_op_status::timeout == c.push_wait_until( 1,
                     std::chrono::system_clock::now() + std::chrono::seconds( 1) ) );
 }
 
-void test_pop() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.pop( v2) );
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_pop_closed() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     c.close();
@@ -140,8 +147,8 @@ void test_pop_closed() {
     BOOST_CHECK( boost::fibers::channel_op_status::closed == c.pop( v2) );
 }
 
-void test_pop_success() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_success(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     int v1 = 2, v2 = 0;
     boost::fibers::fiber f1( boost::fibers::launch::dispatch, [&c,&v2](){
         BOOST_CHECK( boost::fibers::channel_op_status::success == c.pop( v2) );
@@ -154,16 +161,16 @@ void test_pop_success() {
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_value_pop() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_value_pop(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     v2 = c.value_pop();
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_value_pop_closed() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_value_pop_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     c.close();
@@ -178,8 +185,8 @@ void test_value_pop_closed() {
     BOOST_CHECK( thrown);
 }
 
-void test_value_pop_success() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_value_pop_success(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     int v1 = 2, v2 = 0;
     boost::fibers::fiber f1( boost::fibers::launch::dispatch, [&c,&v2](){
         v2 = c.value_pop();
@@ -192,16 +199,16 @@ void test_value_pop_success() {
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_try_pop() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_try_pop(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.try_pop( v2) );
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_try_pop_closed() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_try_pop_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     c.close();
@@ -210,8 +217,8 @@ void test_try_pop_closed() {
     BOOST_CHECK( boost::fibers::channel_op_status::closed == c.try_pop( v2) );
 }
 
-void test_try_pop_success() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_try_pop_success(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     int v1 = 2, v2 = 0;
     boost::fibers::fiber f1( boost::fibers::launch::dispatch, [&c,&v2](){
         while ( boost::fibers::channel_op_status::success != c.try_pop( v2) ) {
@@ -226,16 +233,16 @@ void test_try_pop_success() {
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_pop_wait_for() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_wait_for(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.pop_wait_for( v2, std::chrono::seconds( 1) ) );
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_pop_wait_for_closed() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_wait_for_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     c.close();
@@ -244,8 +251,8 @@ void test_pop_wait_for_closed() {
     BOOST_CHECK( boost::fibers::channel_op_status::closed == c.pop_wait_for( v2, std::chrono::seconds( 1) ) );
 }
 
-void test_pop_wait_for_success() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_wait_for_success(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     int v1 = 2, v2 = 0;
     boost::fibers::fiber f1( boost::fibers::launch::dispatch, [&c,&v2](){
         BOOST_CHECK( boost::fibers::channel_op_status::success == c.pop_wait_for( v2, std::chrono::seconds( 1) ) );
@@ -258,8 +265,8 @@ void test_pop_wait_for_success() {
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_pop_wait_for_timeout() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_wait_for_timeout(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     int v = 0;
     boost::fibers::fiber f( boost::fibers::launch::dispatch, [&c,&v](){
         BOOST_CHECK( boost::fibers::channel_op_status::timeout == c.pop_wait_for( v, std::chrono::seconds( 1) ) );
@@ -267,8 +274,8 @@ void test_pop_wait_for_timeout() {
     f.join();
 }
 
-void test_pop_wait_until() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_wait_until(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.pop_wait_until( v2,
@@ -276,8 +283,8 @@ void test_pop_wait_until() {
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_pop_wait_until_closed() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_wait_until_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     c.close();
@@ -288,8 +295,8 @@ void test_pop_wait_until_closed() {
             std::chrono::system_clock::now() + std::chrono::seconds( 1) ) );
 }
 
-void test_pop_wait_until_success() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_wait_until_success(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     int v1 = 2, v2 = 0;
     boost::fibers::fiber f1( boost::fibers::launch::dispatch, [&c,&v2](){
         BOOST_CHECK( boost::fibers::channel_op_status::success == c.pop_wait_until( v2,
@@ -303,8 +310,8 @@ void test_pop_wait_until_success() {
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_pop_wait_until_timeout() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_wait_until_timeout(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c( channel_size);
     int v = 0;
     boost::fibers::fiber f( boost::fibers::launch::dispatch, [&c,&v](){
         BOOST_CHECK( boost::fibers::channel_op_status::timeout == c.pop_wait_until( v,
@@ -443,8 +450,8 @@ void test_wm_2() {
     BOOST_CHECK_EQUAL( id2, ids[11]);
 }
 
-void test_moveable() {
-    boost::fibers::buffered_channel< moveable > c( 16);
+void test_moveable(size_t channel_size) {
+    boost::fibers::buffered_channel< moveable > c( channel_size);
     moveable m1( 3), m2;
     BOOST_CHECK( m1.state);
     BOOST_CHECK_EQUAL( 3, m1.value);
@@ -460,7 +467,7 @@ void test_moveable() {
     BOOST_CHECK_EQUAL( 3, m2.value);
 }
 
-void test_rangefor() {
+void test_rangefor(size_t channel_size) {
     boost::fibers::buffered_channel< int > chan{ 4 };
     std::vector< int > vec;
     boost::fibers::fiber f1( boost::fibers::launch::dispatch, [&chan]{
@@ -493,39 +500,42 @@ boost::unit_test::test_suite * init_unit_test_suite( int, char* []) {
     boost::unit_test::test_suite * test =
         BOOST_TEST_SUITE("Boost.Fiber: buffered_channel test suite");
 
+    auto size_2 = { 2, 3 };
+    auto size_16 = { 16, 17 };
+
      test->add( BOOST_TEST_CASE( & test_zero_wm) );
-     test->add( BOOST_TEST_CASE( & test_push) );
-     test->add( BOOST_TEST_CASE( & test_push_closed) );
-     test->add( BOOST_TEST_CASE( & test_try_push) );
-     test->add( BOOST_TEST_CASE( & test_try_push_closed) );
-     test->add( BOOST_TEST_CASE( & test_try_push_full) );
-     test->add( BOOST_TEST_CASE( & test_push_wait_for) );
-     test->add( BOOST_TEST_CASE( & test_push_wait_for_closed) );
-     test->add( BOOST_TEST_CASE( & test_push_wait_for_timeout) );
-     test->add( BOOST_TEST_CASE( & test_push_wait_until) );
-     test->add( BOOST_TEST_CASE( & test_push_wait_until_closed) );
-     test->add( BOOST_TEST_CASE( & test_push_wait_until_timeout) );
-     test->add( BOOST_TEST_CASE( & test_pop) );
-     test->add( BOOST_TEST_CASE( & test_pop_closed) );
-     test->add( BOOST_TEST_CASE( & test_pop_success) );
-     test->add( BOOST_TEST_CASE( & test_value_pop) );
-     test->add( BOOST_TEST_CASE( & test_value_pop_closed) );
-     test->add( BOOST_TEST_CASE( & test_value_pop_success) );
-     test->add( BOOST_TEST_CASE( & test_try_pop) );
-     test->add( BOOST_TEST_CASE( & test_try_pop_closed) );
-     test->add( BOOST_TEST_CASE( & test_try_pop_success) );
-     test->add( BOOST_TEST_CASE( & test_pop_wait_for) );
-     test->add( BOOST_TEST_CASE( & test_pop_wait_for_closed) );
-     test->add( BOOST_TEST_CASE( & test_pop_wait_for_success) );
-     test->add( BOOST_TEST_CASE( & test_pop_wait_for_timeout) );
-     test->add( BOOST_TEST_CASE( & test_pop_wait_until) );
-     test->add( BOOST_TEST_CASE( & test_pop_wait_until_closed) );
-     test->add( BOOST_TEST_CASE( & test_pop_wait_until_success) );
-     test->add( BOOST_TEST_CASE( & test_pop_wait_until_timeout) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_push, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_push_closed, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_try_push, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_try_push_closed, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_try_push_full, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_push_wait_for, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_push_wait_for_closed, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_push_wait_for_timeout, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_push_wait_until, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_push_wait_until_closed, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_push_wait_until_timeout, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_closed, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_success, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_value_pop, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_value_pop_closed, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_value_pop_success, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_try_pop, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_try_pop_closed, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_try_pop_success, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_wait_for, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_wait_for_closed, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_wait_for_success, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_wait_for_timeout, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_wait_until, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_wait_until_closed, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_wait_until_success, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_wait_until_timeout, size_16.begin(), size_16.end()) );
      test->add( BOOST_TEST_CASE( & test_wm_1) );
      test->add( BOOST_TEST_CASE( & test_wm_2) );
-     test->add( BOOST_TEST_CASE( & test_moveable) );
-     test->add( BOOST_TEST_CASE( & test_rangefor) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_moveable, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_rangefor, size_2.begin(), size_2.end()) );
 
     return test;
 }

--- a/test/test_buffered_channel_post.cpp
+++ b/test/test_buffered_channel_post.cpp
@@ -11,6 +11,7 @@
 
 #include <boost/assert.hpp>
 #include <boost/test/unit_test.hpp>
+#include <boost/test/parameterized_test.hpp>
 
 #include <boost/fiber/all.hpp>
 
@@ -55,83 +56,89 @@ void test_zero_wm() {
     BOOST_CHECK( thrown);
 }
 
-void test_push() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_push(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( 1) );
 }
 
-void test_push_closed() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_push_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     c.close();
     BOOST_CHECK( boost::fibers::channel_op_status::closed == c.push( 1) );
 }
 
-void test_try_push() {
-    boost::fibers::buffered_channel< int > c( 2);
+void test_try_push(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( 1) );
 }
 
-void test_try_push_closed() {
-    boost::fibers::buffered_channel< int > c( 2);
+void test_try_push_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.try_push( 1) );
     c.close();
     BOOST_CHECK( boost::fibers::channel_op_status::closed == c.try_push( 2) );
 }
 
-void test_try_push_full() {
-    boost::fibers::buffered_channel< int > c( 2);
-    BOOST_CHECK( boost::fibers::channel_op_status::success == c.try_push( 1) );
-    BOOST_CHECK( boost::fibers::channel_op_status::full == c.try_push( 2) );
+void test_try_push_full(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
+    for (int i = 1; i != static_cast<int>( channel_size); ++i) {
+        BOOST_CHECK( boost::fibers::channel_op_status::success == c.try_push( i) );
+    }
+    BOOST_CHECK( boost::fibers::channel_op_status::full == c.try_push( channel_size) );
 }
 
-void test_push_wait_for() {
-    boost::fibers::buffered_channel< int > c( 2);
+void test_push_wait_for(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push_wait_for( 1, std::chrono::seconds( 1) ) );
 }
 
-void test_push_wait_for_closed() {
-    boost::fibers::buffered_channel< int > c( 2);
+void test_push_wait_for_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     c.close();
     BOOST_CHECK( boost::fibers::channel_op_status::closed == c.push_wait_for( 1, std::chrono::seconds( 1) ) );
 }
 
-void test_push_wait_for_timeout() {
-    boost::fibers::buffered_channel< int > c( 2);
-    BOOST_CHECK( boost::fibers::channel_op_status::success == c.push_wait_for( 1, std::chrono::seconds( 1) ) );
-    BOOST_CHECK( boost::fibers::channel_op_status::timeout == c.push_wait_for( 2, std::chrono::seconds( 1) ) );
+void test_push_wait_for_timeout(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
+    for (int i = 1; i != static_cast<int>( channel_size); ++i) {
+        BOOST_CHECK( boost::fibers::channel_op_status::success == c.push_wait_for( i, std::chrono::seconds( 1) ) );
+    }
+    BOOST_CHECK( boost::fibers::channel_op_status::timeout == c.push_wait_for( channel_size, std::chrono::seconds( 1) ) );
 }
 
-void test_push_wait_until() {
-    boost::fibers::buffered_channel< int > c( 2);
+void test_push_wait_until(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push_wait_until( 1,
                     std::chrono::system_clock::now() + std::chrono::seconds( 1) ) );
 }
 
-void test_push_wait_until_closed() {
-    boost::fibers::buffered_channel< int > c( 2);
+void test_push_wait_until_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     c.close();
     BOOST_CHECK( boost::fibers::channel_op_status::closed == c.push_wait_until( 1,
                     std::chrono::system_clock::now() + std::chrono::seconds( 1) ) );
 }
 
-void test_push_wait_until_timeout() {
-    boost::fibers::buffered_channel< int > c( 2);
-    BOOST_CHECK( boost::fibers::channel_op_status::success == c.push_wait_until( 1,
+void test_push_wait_until_timeout(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
+    for (int i = 1; i != static_cast<int>( channel_size); ++i) {
+        BOOST_CHECK( boost::fibers::channel_op_status::success == c.push_wait_until( i,
                     std::chrono::system_clock::now() + std::chrono::seconds( 1) ) );
-    BOOST_CHECK( boost::fibers::channel_op_status::timeout == c.push_wait_until( 2,
+    }
+    BOOST_CHECK( boost::fibers::channel_op_status::timeout == c.push_wait_until( channel_size,
                     std::chrono::system_clock::now() + std::chrono::seconds( 1) ) );
 }
 
-void test_pop() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.pop( v2) );
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_pop_closed() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     c.close();
@@ -140,8 +147,8 @@ void test_pop_closed() {
     BOOST_CHECK( boost::fibers::channel_op_status::closed == c.pop( v2) );
 }
 
-void test_pop_success() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_success(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     int v1 = 2, v2 = 0;
     boost::fibers::fiber f1( boost::fibers::launch::post, [&c,&v2](){
         BOOST_CHECK( boost::fibers::channel_op_status::success == c.pop( v2) );
@@ -154,16 +161,16 @@ void test_pop_success() {
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_value_pop() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_value_pop(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     v2 = c.value_pop();
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_value_pop_closed() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_value_pop_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     c.close();
@@ -178,8 +185,8 @@ void test_value_pop_closed() {
     BOOST_CHECK( thrown);
 }
 
-void test_value_pop_success() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_value_pop_success(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     int v1 = 2, v2 = 0;
     boost::fibers::fiber f1( boost::fibers::launch::post, [&c,&v2](){
         v2 = c.value_pop();
@@ -192,16 +199,16 @@ void test_value_pop_success() {
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_try_pop() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_try_pop(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.try_pop( v2) );
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_try_pop_closed() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_try_pop_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     c.close();
@@ -210,8 +217,8 @@ void test_try_pop_closed() {
     BOOST_CHECK( boost::fibers::channel_op_status::closed == c.try_pop( v2) );
 }
 
-void test_try_pop_success() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_try_pop_success(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     int v1 = 2, v2 = 0;
     boost::fibers::fiber f1( boost::fibers::launch::post, [&c,&v2](){
         while ( boost::fibers::channel_op_status::success != c.try_pop( v2) ) {
@@ -226,16 +233,16 @@ void test_try_pop_success() {
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_pop_wait_for() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_wait_for(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.pop_wait_for( v2, std::chrono::seconds( 1) ) );
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_pop_wait_for_closed() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_wait_for_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     c.close();
@@ -244,8 +251,8 @@ void test_pop_wait_for_closed() {
     BOOST_CHECK( boost::fibers::channel_op_status::closed == c.pop_wait_for( v2, std::chrono::seconds( 1) ) );
 }
 
-void test_pop_wait_for_success() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_wait_for_success(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     int v1 = 2, v2 = 0;
     boost::fibers::fiber f1( boost::fibers::launch::post, [&c,&v2](){
         BOOST_CHECK( boost::fibers::channel_op_status::success == c.pop_wait_for( v2, std::chrono::seconds( 1) ) );
@@ -258,8 +265,8 @@ void test_pop_wait_for_success() {
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_pop_wait_for_timeout() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_wait_for_timeout(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     int v = 0;
     boost::fibers::fiber f( boost::fibers::launch::post, [&c,&v](){
         BOOST_CHECK( boost::fibers::channel_op_status::timeout == c.pop_wait_for( v, std::chrono::seconds( 1) ) );
@@ -267,8 +274,8 @@ void test_pop_wait_for_timeout() {
     f.join();
 }
 
-void test_pop_wait_until() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_wait_until(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.pop_wait_until( v2,
@@ -276,8 +283,8 @@ void test_pop_wait_until() {
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_pop_wait_until_closed() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_wait_until_closed(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     int v1 = 2, v2 = 0;
     BOOST_CHECK( boost::fibers::channel_op_status::success == c.push( v1) );
     c.close();
@@ -288,8 +295,8 @@ void test_pop_wait_until_closed() {
             std::chrono::system_clock::now() + std::chrono::seconds( 1) ) );
 }
 
-void test_pop_wait_until_success() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_wait_until_success(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     int v1 = 2, v2 = 0;
     boost::fibers::fiber f1( boost::fibers::launch::post, [&c,&v2](){
         BOOST_CHECK( boost::fibers::channel_op_status::success == c.pop_wait_until( v2,
@@ -303,8 +310,8 @@ void test_pop_wait_until_success() {
     BOOST_CHECK_EQUAL( v1, v2);
 }
 
-void test_pop_wait_until_timeout() {
-    boost::fibers::buffered_channel< int > c( 16);
+void test_pop_wait_until_timeout(size_t channel_size) {
+    boost::fibers::buffered_channel< int > c ( channel_size);
     int v = 0;
     boost::fibers::fiber f( boost::fibers::launch::post, [&c,&v](){
         BOOST_CHECK( boost::fibers::channel_op_status::timeout == c.pop_wait_until( v,
@@ -441,8 +448,8 @@ void test_wm_2() {
     BOOST_CHECK_EQUAL( id2, ids[11]);
 }
 
-void test_moveable() {
-    boost::fibers::buffered_channel< moveable > c( 16);
+void test_moveable(size_t channel_size) {
+    boost::fibers::buffered_channel< moveable > c ( channel_size);
     moveable m1( 3), m2;
     BOOST_CHECK( m1.state);
     BOOST_CHECK_EQUAL( 3, m1.value);
@@ -458,7 +465,7 @@ void test_moveable() {
     BOOST_CHECK_EQUAL( 3, m2.value);
 }
 
-void test_rangefor() {
+void test_rangefor(size_t channel_size) {
     boost::fibers::buffered_channel< int > chan{ 2 };
     std::vector< int > vec;
     boost::fibers::fiber f1([&chan]{
@@ -491,39 +498,42 @@ boost::unit_test::test_suite * init_unit_test_suite( int, char* []) {
     boost::unit_test::test_suite * test =
         BOOST_TEST_SUITE("Boost.Fiber: buffered_channel test suite");
 
+    auto size_2 = { 2, 3 };
+    auto size_16 = { 16, 17 };
+
      test->add( BOOST_TEST_CASE( & test_zero_wm) );
-     test->add( BOOST_TEST_CASE( & test_push) );
-     test->add( BOOST_TEST_CASE( & test_push_closed) );
-     test->add( BOOST_TEST_CASE( & test_try_push) );
-     test->add( BOOST_TEST_CASE( & test_try_push_closed) );
-     test->add( BOOST_TEST_CASE( & test_try_push_full) );
-     test->add( BOOST_TEST_CASE( & test_push_wait_for) );
-     test->add( BOOST_TEST_CASE( & test_push_wait_for_closed) );
-     test->add( BOOST_TEST_CASE( & test_push_wait_for_timeout) );
-     test->add( BOOST_TEST_CASE( & test_push_wait_until) );
-     test->add( BOOST_TEST_CASE( & test_push_wait_until_closed) );
-     test->add( BOOST_TEST_CASE( & test_push_wait_until_timeout) );
-     test->add( BOOST_TEST_CASE( & test_pop) );
-     test->add( BOOST_TEST_CASE( & test_pop_closed) );
-     test->add( BOOST_TEST_CASE( & test_pop_success) );
-     test->add( BOOST_TEST_CASE( & test_value_pop) );
-     test->add( BOOST_TEST_CASE( & test_value_pop_closed) );
-     test->add( BOOST_TEST_CASE( & test_value_pop_success) );
-     test->add( BOOST_TEST_CASE( & test_try_pop) );
-     test->add( BOOST_TEST_CASE( & test_try_pop_closed) );
-     test->add( BOOST_TEST_CASE( & test_try_pop_success) );
-     test->add( BOOST_TEST_CASE( & test_pop_wait_for) );
-     test->add( BOOST_TEST_CASE( & test_pop_wait_for_closed) );
-     test->add( BOOST_TEST_CASE( & test_pop_wait_for_success) );
-     test->add( BOOST_TEST_CASE( & test_pop_wait_for_timeout) );
-     test->add( BOOST_TEST_CASE( & test_pop_wait_until) );
-     test->add( BOOST_TEST_CASE( & test_pop_wait_until_closed) );
-     test->add( BOOST_TEST_CASE( & test_pop_wait_until_success) );
-     test->add( BOOST_TEST_CASE( & test_pop_wait_until_timeout) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_push, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_push_closed, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_try_push, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_try_push_closed, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_try_push_full, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_push_wait_for, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_push_wait_for_closed, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_push_wait_for_timeout, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_push_wait_until, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_push_wait_until_closed, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_push_wait_until_timeout, size_2.begin(), size_2.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_closed, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_success, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_value_pop, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_value_pop_closed, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_value_pop_success, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_try_pop, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_try_pop_closed, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_try_pop_success, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_wait_for, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_wait_for_closed, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_wait_for_success, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_wait_for_timeout, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_wait_until, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_wait_until_closed, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_wait_until_success, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_pop_wait_until_timeout, size_16.begin(), size_16.end()) );
      test->add( BOOST_TEST_CASE( & test_wm_1) );
      test->add( BOOST_TEST_CASE( & test_wm_2) );
-     test->add( BOOST_TEST_CASE( & test_moveable) );
-     test->add( BOOST_TEST_CASE( & test_rangefor) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_moveable, size_16.begin(), size_16.end()) );
+     test->add( BOOST_PARAM_TEST_CASE( & test_rangefor, size_2.begin(), size_2.end()) );
 
     return test;
 }


### PR DESCRIPTION
Relax restrictions on capacity of buffered_channel (allow capacity that's not a power of two)

There's no reasons for such restriction since 0a6384dd7726b9931d6312922aadbe21b1178833. Also implement tests for "capacity is not a power of two" case

Closes #329 